### PR TITLE
Unify image source types between banner and wallpaper config

### DIFF
--- a/src/components/misc/FullscreenWallpaper.astro
+++ b/src/components/misc/FullscreenWallpaper.astro
@@ -42,10 +42,33 @@ const getImageSources = async () => {
 		}
 	}
 
-	const { desktop, mobile } = srcConfig;
+	const toArray = (src: string | string[] | undefined): string[] => {
+		if (Array.isArray(src)) return src;
+		if (typeof src === "string") return [src];
+		return [];
+	};
+	if (
+		typeof srcConfig === "object" &&
+		srcConfig !== null &&
+		!Array.isArray(srcConfig) &&
+		("desktop" in srcConfig || "mobile" in srcConfig)
+	) {
+		const srcObj = srcConfig as {
+			desktop?: string | string[];
+			mobile?: string | string[]
+		};
+		const desktop = toArray(srcObj.desktop);
+		const mobile = toArray(srcObj.mobile);
+		return {
+			desktop: desktop.length > 0 ? desktop : mobile,
+			mobile: mobile.length > 0 ? mobile : desktop,
+		};
+	}
+	// 如果是字符串或字符串数组，同时用于桌面端和移动端
+	const allImages = toArray(srcConfig as string | string[]);
 	return {
-		desktop: Array.isArray(desktop) ? desktop : desktop ? [desktop] : [],
-		mobile: Array.isArray(mobile) ? mobile : mobile ? [mobile] : [],
+		desktop: allImages,
+		mobile: allImages,
 	};
 };
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -272,10 +272,13 @@ export type SakuraConfig = {
 
 export type FullscreenWallpaperConfig = {
 	enable: boolean; // 是否启用全屏壁纸功能
-	src: {
-		desktop?: string | string[]; // 桌面端壁纸图片
-		mobile?: string | string[]; // 移动端壁纸图片
-	};
+	src:
+		| string
+		| string[]
+		| {
+				desktop?: string | string[];
+				mobile?: string | string[];
+		  }; // 支持单个图片、图片数组或分别设置桌面端和移动端图片
 	position?: "top" | "center" | "bottom"; // 壁纸位置，等同于 object-position
 	carousel?: {
 		enable: boolean; // 是否启用轮播


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->
- Align FullscreenWallpaperConfig.src type with SiteConfig.banner.src type to support multiple source formats
- Update getImageSources function to handle unified type structure


## How To Test

<!-- Please describe how you tested your changes. -->
1. Set `siteConfig.banner.enable` to `false`
```typescript
	banner: {
		enable: false, // 是否启动Banner壁纸模式
```
2. Set `fullscreenWallpaperConfig.src`'s `desktop`&`mobile` props to `string or array` value
```typescript
	enable: true, // 启用全屏壁纸功能,非Banner模式下生效
	src: {
		desktop: "/assets/desktop-banner/d1.webp", // 桌面横幅图片
		mobile: "/assets/mobile-banner/m1.webp", // 移动横幅图片
	}, // 使用本地横幅图片
```
3. Save and run `pnpm dev` to test it out

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
<img width="1920" height="1140" alt="屏幕截图 2025-10-05 154120" src="https://github.com/user-attachments/assets/9f506a54-a191-482e-a30a-02d0eeab06d3" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
