### PR TITLE
Upscale Astro's avatar to the same size as the MizukiDoc's avatar

### DIFF
--- a/src/pages/friends.astro
+++ b/src/pages/friends.astro
@@ -16,7 +16,7 @@ const { Content } = await render(friendsPost);
 const items = [
 	{
 		title: "Astro",
-		imgurl: "https://avatars.githubusercontent.com/u/44914786?s=48&v=4",
+		imgurl: "https://avatars.githubusercontent.com/u/44914786?v=4&s=640",
 		desc: "The web framework for content-driven websites. ⭐️ Star to support our work!",
 		siteurl: "https://github.com/withastro/astro",
 		tags: ["Framework"],


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->
Upscale Astro's avatar to the same size as the MizukiDoc's avatar to make it looks clearer especially on desktop.


## How To Test

<!-- Please describe how you tested your changes. -->
Run `pnpm dev` to test it out.


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
<img width="1920" height="1140" alt="屏幕截图 2025-10-07 145912" src="https://github.com/user-attachments/assets/180587a3-c2f6-4c9d-9295-8b6b64c61b4d" />



## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
I've checked the `v=4` query param and found it not that neccessary in the url, which means it can be deleted without fetching the avatar, but still I chose to keep it:)