### PR TITLE
Simplify umamiConfig

### DIFF
--- a/src/components/PostMeta.astro
+++ b/src/components/PostMeta.astro
@@ -10,7 +10,7 @@ import { umamiConfig } from '../config';
 
 // 解析 umami
 const umamiEnabled = umamiConfig.enabled || false;
-const umamiWebsiteId = umamiConfig.websiteId || "";
+const umamiWebsiteId = umamiConfig.scripts.match(/data-website-id="([^"]+)"/)?.[1] || "";
 const umamiApiKey = umamiConfig.apiKey || "";
 const umamiBaseUrl = umamiConfig.baseUrl || "";
 

--- a/src/components/widget/Profile.astro
+++ b/src/components/widget/Profile.astro
@@ -8,7 +8,7 @@ import { umamiConfig } from '../../config';
 
 // 解析 umami
 const umamiEnabled = umamiConfig.enabled || false;
-const umamiWebsiteId = umamiConfig.websiteId || "";
+const umamiWebsiteId = umamiConfig.scripts.match(/data-website-id="([^"]+)"/)?.[1] || "";
 const umamiApiKey = umamiConfig.apiKey || "";
 const umamiBaseUrl = umamiConfig.baseUrl || "";
 ---

--- a/src/config.ts
+++ b/src/config.ts
@@ -492,7 +492,6 @@ export const widgetConfigs = {
 
 export const umamiConfig = {
 	enabled: false, // 是否显示Umami统计
-	websiteId: "abcd", // 你的网站ID
 	apiKey: "api_XXXXXXXXXX", // 你的API密钥
 	baseUrl: "https://api.umami.is", // Umami Cloud API地址
 	scripts: `


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->
- Remove the websiteId param from umamiConfig
- Fetch umamiWebsiteId via the scripts param using match statement

## How To Test

<!-- Please describe how you tested your changes. -->
1.  Customize the following params for `umamiConfig`:
```
	enabled: true,
	apiKey: "api_XXXXXXXXXX",
	scripts: `<script defer src="XXXX.XXX" data-website-id="ABCD1234"></script>`.trim()
```

2. Run `pnpm dev` to test it out locally.


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
Take my personal blog for example (notice the analytics in right corner):
<img width="800" height="570" alt="blog spr-aachen com_" src="https://github.com/user-attachments/assets/8142fdfa-1a1f-4c38-8173-b5df51868220" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
I also noticed the `baseUrl` param which should be always using `"https://api.umami.is"` as its permanent value, so perhaps we can also remove it.