### PR TITLE
fix: toc无法根据页面滚动而自动滚动

### DIFF
--- a/src/components/widget/TOC.astro
+++ b/src/components/widget/TOC.astro
@@ -316,3 +316,17 @@ if (!customElements.get("table-of-contents")) {
     customElements.define("table-of-contents", TableOfContents);
 }
 </script>
+
+<style>
+  table-of-contents#toc {
+      max-height: 100%;
+      overflow: auto;
+      position: relative;
+      scroll-behavior: smooth;
+      display: block;
+  }
+
+  table-of-contents#toc::-webkit-scrollbar {
+      display: none;
+  }
+</style>


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

修复toc在页面滚动时虽然活跃指示器是正常的但并不会跟随活跃指示器滚动toc

bug gif:
![chrome-capture-2025-10-16 (1)](https://github.com/user-attachments/assets/dd7f2c7d-6cdc-4f82-8d64-ad7e9f81c037)

## Changes

根据测试是发现toc的css缺失导致无法滚动，至添加对应css

## How To Test

just scroll through the post page and view the toc

## Screenshots (if applicable)

fix gif:
![chrome-capture-2025-10-16 (2)](https://github.com/user-attachments/assets/971dd9ee-65b8-4fcc-874c-3ef3c05b9450)

## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
