### PR TITLE
fix: #115 #61

### DIFF
--- a/src/components/control/BackToTop.astro
+++ b/src/components/control/BackToTop.astro
@@ -1,10 +1,11 @@
 ---
-import { Icon } from "astro-icon/components";
+import {Icon} from "astro-icon/components";
 ---
 
 <!-- There can't be a filter on parent element, or it will break `fixed` -->
-<div class="back-to-top-wrapper hidden lg:block">
-    <div id="back-to-top-btn" class="back-to-top-btn hide flex items-center rounded-2xl overflow-hidden transition" onclick="backToTop()">
+<div class="back-to-top-wrapper block">
+    <div id="back-to-top-btn" class="back-to-top-btn hide flex items-center rounded-2xl overflow-hidden transition"
+         onclick="backToTop()">
         <button aria-label="Back to Top" class="btn-card h-[3.75rem] w-[3.75rem]">
             <Icon name="material-symbols:keyboard-arrow-up-rounded" class="mx-auto"></Icon>
         </button>
@@ -12,7 +13,7 @@ import { Icon } from "astro-icon/components";
 </div>
 
 <style lang="stylus">
-.back-to-top-wrapper
+  .back-to-top-wrapper
     width: 3.75rem
     height: 3.75rem
     position: absolute
@@ -20,7 +21,7 @@ import { Icon } from "astro-icon/components";
     top: 0
     pointer-events: none
 
-.back-to-top-btn
+  .back-to-top-btn
     color: var(--primary)
     font-size: 2.25rem
     font-weight: bold
@@ -28,23 +29,34 @@ import { Icon } from "astro-icon/components";
     position: fixed
     bottom: 10rem
     opacity: 1
+    right: 6rem
     cursor: pointer
     transform: translateX(5rem)
     pointer-events: auto
+    transition: box-shadow 1s ease-in-out
+
     i
-        font-size: 1.75rem
+      font-size: 1.75rem
+
     &.hide
-        transform: translateX(5rem) scale(0.9)
-        opacity: 0
-        pointer-events: none
+      transform: translateX(5rem) scale(0.9)
+      opacity: 0
+      pointer-events: none
+
     &:active
       transform: translateX(5rem) scale(0.9)
+
+  @media (max-width: 1560px)
+    .back-to-top-btn
+      box-shadow:
+              0 0 0 1px var(--btn-regular-bg) ,
+              0 0 1em var(--btn-regular-bg) ;
 
 </style>
 
 <script is:raw is:inline>
-function backToTop() {
-    // 直接使用原生滚动，避免OverlayScrollbars冲突
-    window.scroll({ top: 0, behavior: 'smooth' });
-}
+    function backToTop() {
+        // 直接使用原生滚动，避免OverlayScrollbars冲突
+        window.scroll({top: 0, behavior: 'smooth'});
+    }
 </script>

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -392,7 +392,7 @@ const transparentClass = shouldEnableTransparency
 </div>
 
 <!-- The things that should be under the banner, only the TOC for now -->
-<div class="absolute w-full z-0 hidden xl:block">
+<div class="absolute w-full z-0 hidden 2xl:block">
     <div class="relative max-w-[var(--page-width)] mx-auto">
         <!-- TOC component -->
         {siteConfig.toc.enable && <div id="toc-wrapper" class:list={["hidden lg:block transition absolute top-0 w-[var(--toc-width)] items-center",
@@ -747,8 +747,10 @@ const transparentClass = shouldEnableTransparency
         transition: top 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.1s;
         /* 硬件加速优化 */
         will-change: top;
+        /* 禁用transform以保证back to top 按钮可以显示
         transform: translateZ(0);
         -webkit-transform: translateZ(0);
+        */
     }
     
     .absolute.w-full.z-30.mobile-main-no-banner {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -366,7 +366,7 @@ html {
   --_spoiler-mask: var(--primary);
   @apply hover:bg-transparent px-1 py-0.5 overflow-hidden rounded-md transition-all duration-150;
   background-color: var(--_spoiler-mask);
-
+  box-decoration-break: clone;
   &:not(:hover) {
     color: var(--_spoiler-mask);
     * {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

#115 #61 

## Changes

fix: spoiler在移动端被断行时头尾部并不是圆角
fix: 小于1024px的屏幕不会显示back to top按钮
fix: back to top按钮会在小于~1800px(实际宽度在此宽度下)时会被顶出屏幕


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

fix: spoiler在移动端被断行时头尾部并不是圆角
<img width="434" height="259" alt="image" src="https://github.com/user-attachments/assets/f6a2f8a3-df39-4905-bbde-88d08936337d" />

fix: 小于1024px的屏幕不会显示back to top按钮
fix: back to top按钮会在小于~1800px(实际宽度在此宽度下)时会被顶出屏幕

![chrome-capture-2025-10-16 (4) (1)](https://github.com/user-attachments/assets/4775c424-bc94-4a60-b4fa-8a9225786bcd)

防止返回顶部按钮的背景色与文章背景色融为一体，添加box-shadow进行区分
<img width="627" height="411" alt="image" src="https://github.com/user-attachments/assets/f47ed451-c2df-45d8-a4e2-7f6262e16d74" />




## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
