### PR TITLE
Update content collections to use Content Loader API

### DIFF
--- a/src/components/ArchivePanel.svelte
+++ b/src/components/ArchivePanel.svelte
@@ -15,7 +15,7 @@ categories = params.has("category") ? params.getAll("category") : [];
 const uncategorized = params.get("uncategorized");
 
 interface Post {
-	slug: string;
+	id: string;
 	data: {
 		title: string;
 		tags: string[];
@@ -32,7 +32,7 @@ function getPostUrl(post: Post): string {
 		return getPostUrlByPermalink(post.data.permalink);
 	}
 	// 否则使用默认的 slug 路径
-	return getPostUrlBySlug(post.slug);
+	return getPostUrlBySlug(post.id);
 }
 
 interface Group {

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,10 +1,11 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import { render } from "astro:content";
 import * as path from "node:path";
 import { Icon } from "astro-icon/components";
 import I18nKey from "../i18n/i18nKey";
 import { i18n } from "../i18n/translation";
-import { getDir, getTagUrl } from "../utils/url-utils";
+import { getDir, getTagUrl, getFileDirFromPath } from "@/utils/url-utils";
 import { siteConfig } from "../config";
 import ImageWrapper from "./misc/ImageWrapper.astro";
 import PostMetadata from "./PostMeta.astro";
@@ -43,7 +44,7 @@ const hasCover = image !== undefined && image !== null && image !== "";
 
 const coverWidth = "28%";
 
-const { remarkPluginFrontmatter } = await entry.render();
+const { remarkPluginFrontmatter } = await render(entry);
 ---
 
 <div class:list={["card-base flex flex-col-reverse md:flex-col w-full rounded-[var(--radius-large)] overflow-hidden relative", className]} style={style}>
@@ -104,7 +105,7 @@ const { remarkPluginFrontmatter } = await entry.render();
                   class="transition opacity-0 group-hover:opacity-100 scale-50 group-hover:scale-100 text-white text-5xl">
             </Icon>
         </div>
-        <ImageWrapper src={image} basePath={path.join("content/posts/", getDir(entry.id))} alt="Cover Image of the Post"
+        <ImageWrapper src={image} basePath={getFileDirFromPath(entry.filePath || '')} alt="Cover Image of the Post"
                   class="w-full h-full">
         </ImageWrapper>
     </a>}

--- a/src/components/PostMeta.astro
+++ b/src/components/PostMeta.astro
@@ -22,7 +22,7 @@ export interface Props {
 	hideTagsForMobile?: boolean;
 	isHome?: boolean;
 	className?: string;
-	slug?: string;
+	id?: string;
 	showOnlyBasicMeta?: boolean; // 新增属性，控制是否只显示基本元数据
 	words?: number; // 字数统计
 	minutes?: number; // 阅读时间（分钟）
@@ -38,7 +38,7 @@ const {
 	hideTagsForMobile,
 	isHome,
 	className = "",
-	slug,
+	id,
 	showOnlyBasicMeta = false, // 默认为false，保持原有行为
 	words,
 	minutes,
@@ -114,7 +114,7 @@ const {
     )}
     
     <!-- 访问量（首页不显示，且umami.enabled为true时显示） -->
-    {!isHome && umamiEnabled && slug && (
+    {!isHome && umamiEnabled && id && (
         <div class="flex items-center">
             <div class="meta-icon">
                 <Icon name="material-symbols:visibility-outline-rounded" class="text-xl"></Icon>
@@ -125,8 +125,8 @@ const {
 </div>
 
 <!-- 只有在非首页且启用umami且有slug时才加载脚本 -->
-{!isHome && umamiEnabled && slug && (
-    <script define:vars={{ slug, umamiBaseUrl, umamiApiKey, umamiWebsiteId, umamiConfig }}>
+{!isHome && umamiEnabled && id && (
+    <script define:vars={{ id, umamiBaseUrl, umamiApiKey, umamiWebsiteId, umamiConfig }}>
         // 客户端统计文案生成函数
         function generateStatsText(pageViews, visitors) {
             return `浏览量 ${pageViews} · 访客 ${visitors}`;
@@ -140,7 +140,7 @@ const {
             
             try {
                 // 构造文章页面的URL路径
-                const pageUrl = `/posts/${slug}/`;
+                const pageUrl = `/posts/${id}/`;
                 
                 // 调用全局工具获取特定页面的 Umami 统计数据
                 const stats = await getUmamiPageStats(umamiBaseUrl, umamiApiKey, umamiWebsiteId, pageUrl);

--- a/src/components/comment/index.astro
+++ b/src/components/comment/index.astro
@@ -1,14 +1,16 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { commentConfig } from "@/config";
+import { removeFileExtension } from "@/utils/url-utils";
 import Twikoo from "./Twikoo.astro";
 
 interface Props {
 	post: CollectionEntry<"posts">;
 }
 
-const { id, data, slug } = Astro.props.post;
+const { id, data } = Astro.props.post;
 
+const slug = removeFileExtension(id);
 const path = `/posts/${slug}`;
 const url = `${Astro.site?.href}${path}`;
 

--- a/src/components/misc/License.astro
+++ b/src/components/misc/License.astro
@@ -7,7 +7,7 @@ import { formatDateToYYYYMMDD } from "../../utils/date-utils";
 
 interface Props {
 	title: string;
-	slug: string;
+	id: string;
 	pubDate: Date;
 	class: string;
 	author: string;

--- a/src/components/widget/Calendar.astro
+++ b/src/components/widget/Calendar.astro
@@ -26,7 +26,7 @@ posts.forEach(post => {
 
 // 序列化所有文章数据供客户端使用
 const allPostsData = posts.map(post => ({
-  slug: post.slug,
+  id: post.id,
   title: post.data.title,
   published: post.data.published.toISOString()
 }));
@@ -186,7 +186,7 @@ const yearSuffix = isChinese ? '年' : ' ';
     
     if (postsList) {
       postsList.innerHTML = currentMonthPosts.map(post => `
-        <a href="/posts/${post.slug}/" class="block text-sm text-neutral-700 dark:text-neutral-300 hover:text-[var(--primary)] dark:hover:text-[var(--primary)] transition-colors truncate px-2 py-1 rounded hover:bg-[var(--btn-plain-bg-hover)]">
+        <a href="/posts/${post.id}/" class="block text-sm text-neutral-700 dark:text-neutral-300 hover:text-[var(--primary)] dark:hover:text-[var(--primary)] transition-colors truncate px-2 py-1 rounded hover:bg-[var(--btn-plain-bg-hover)]">
           ${post.title}
         </a>
       `).join('');
@@ -237,7 +237,7 @@ const yearSuffix = isChinese ? '年' : ' ';
         if (posts.length > 0 && postsList) {
           // 渲染文章列表
           postsList.innerHTML = posts.map(post => `
-            <a href="/posts/${post.slug}/" class="block text-sm text-neutral-700 dark:text-neutral-300 hover:text-[var(--primary)] dark:hover:text-[var(--primary)] transition-colors truncate px-2 py-1 rounded hover:bg-[var(--btn-plain-bg-hover)]">
+            <a href="/posts/${post.id}/" class="block text-sm text-neutral-700 dark:text-neutral-300 hover:text-[var(--primary)] dark:hover:text-[var(--primary)] transition-colors truncate px-2 py-1 rounded hover:bg-[var(--btn-plain-bg-hover)]">
               ${post.data.title}
             </a>
           `).join('');

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,8 @@
 import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
 
 const postsCollection = defineCollection({
+	loader: glob({ pattern: "**/*.md", base: "./src/content/posts" }),
 	schema: z.object({
 		title: z.string(),
 		published: z.date(),
@@ -32,6 +34,7 @@ const postsCollection = defineCollection({
 	}),
 });
 const specCollection = defineCollection({
+	loader: glob({ pattern: "**/*.md", base: "./src/content/spec" }),
 	schema: z.object({}),
 });
 export const collections = {

--- a/src/pages/atom.astro
+++ b/src/pages/atom.astro
@@ -62,7 +62,7 @@ const recentPosts = posts.slice(0, 6);
                 {recentPosts.map((post) => (
                     <article class="bg-[var(--card-bg)] rounded-xl p-4 border border-[var(--line-divider)] hover:border-[var(--primary)] transition-all duration-300">
                         <h3 class="text-lg font-semibold text-90 mb-2 hover:text-[var(--primary)] transition-colors">
-                            <a href={`/posts/${post.slug}/`} class="hover:underline">
+                            <a href={`/posts/${post.id}/`} class="hover:underline">
                                 {post.data.title}
                             </a>
                         </h3>

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import type { APIContext, GetStaticPaths } from "astro";
 import satori from "satori";
 import sharp from "sharp";
+import { removeFileExtension } from "@/utils/url-utils";
 
 import { profileConfig, siteConfig } from "../../config";
 
@@ -26,10 +27,14 @@ export const getStaticPaths: GetStaticPaths = async () => {
 	const allPosts = await getCollection("posts");
 	const publishedPosts = allPosts.filter((post) => !post.data.draft);
 
-	return publishedPosts.map((post) => ({
-		params: { slug: post.slug },
-		props: { post },
-	}));
+  return publishedPosts.map((post) => {
+    // 将 id 转换为 slug（移除扩展名）以匹配路由参数
+    const slug = removeFileExtension(post.id);
+    return {
+      params: { slug },
+      props: { post },
+    };
+  });
 };
 
 let fontCache: { regular: Buffer | null; bold: Buffer | null } | null = null;

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -8,7 +8,8 @@ import I18nKey from "@i18n/i18nKey";
 import { i18n } from "@i18n/translation";
 import MainGridLayout from "@layouts/MainGridLayout.astro";
 import { getSortedPosts } from "@utils/content-utils";
-import { getDir, getPostUrlBySlug } from "@utils/url-utils";
+import { getDir, getPostUrlBySlug, removeFileExtension, getFileDirFromPath } from "@utils/url-utils";
+import { render } from "astro:content";
 import { Icon } from "astro-icon/components";
 import bcryptjs from "bcryptjs";
 import CryptoJS from "crypto-js";
@@ -26,9 +27,12 @@ export async function getStaticPaths() {
 	const paths: { params: { slug: string }, props: { entry: CollectionEntry<"posts"> } }[] = [];
 	
 	for (const entry of blogEntries) {
+        // 将 id 转换为 slug（移除扩展名）以匹配路由参数
+        const slug = removeFileExtension(entry.id);
+
 		// 为每篇文章创建默认的 slug 路径
 		paths.push({
-			params: { slug: entry.slug },
+			params: { slug },
 			props: { entry },
 		});
 		
@@ -51,9 +55,9 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props;
-const { Content, headings } = await entry.render();
+const { Content, headings } = await render(entry);
 
-const { remarkPluginFrontmatter } = await entry.render();
+const { remarkPluginFrontmatter } = await render(entry);
 
 // 处理加密逻辑
 let encryptedContent = "";
@@ -113,7 +117,7 @@ const jsonLd = {
     description={entry.data.description}
     lang={entry.data.lang}
     setOGTypeArticle={true}
-    postSlug={entry.slug}
+    postSlug={entry.id}
     headings={headings}
 >
     <script is:inline slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
@@ -191,8 +195,8 @@ const jsonLd = {
                     published={entry.data.published}
                     updated={entry.data.updated}
                     tags={entry.data.tags}
-                    category={entry.data.category}
-                    slug={entry.slug}
+                    category={entry.data.category || undefined}
+                    id={entry.id}
                 />
                 {
                     !entry.data.image && (
@@ -210,7 +214,7 @@ const jsonLd = {
                         <ImageWrapper
                             id="post-cover"
                             src={entry.data.image}
-                            basePath={path.join("content/posts/", getDir(entry.id))}
+                            basePath={getFileDirFromPath(entry.filePath || '')}
                             class="mb-8 rounded-xl banner-container onload-animation"
                         />
                     </>
@@ -231,7 +235,7 @@ const jsonLd = {
                         {licenseConfig.enable && (
                             <License
                                 title={entry.data.title}
-                                slug={entry.slug}
+                                id={entry.id}
                                 pubDate={entry.data.published}
                                 author={entry.data.author}
                                 sourceLink={entry.data.sourceLink}

--- a/src/pages/rss.astro
+++ b/src/pages/rss.astro
@@ -66,7 +66,7 @@ const recentPosts = posts.slice(0, 6);
                 {recentPosts.map((post) => (
                     <article class="bg-[var(--card-bg)] rounded-xl p-4 border border-[var(--line-divider)] hover:border-[var(--primary)] transition-all duration-300">
                         <h3 class="text-lg font-semibold text-90 mb-2 hover:text-[var(--primary)] transition-colors">
-                            <a href={`/posts/${post.slug}/`} class="hover:underline">
+                            <a href={`/posts/${post.id}/`} class="hover:underline">
                                 {post.data.title}
                             </a>
                         </h3>

--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -26,18 +26,18 @@ export async function getSortedPosts() {
 	const sorted = await getRawSortedPosts();
 
 	for (let i = 1; i < sorted.length; i++) {
-		sorted[i].data.nextSlug = sorted[i - 1].slug;
+		sorted[i].data.nextSlug = sorted[i - 1].id;
 		sorted[i].data.nextTitle = sorted[i - 1].data.title;
 	}
 	for (let i = 0; i < sorted.length - 1; i++) {
-		sorted[i].data.prevSlug = sorted[i + 1].slug;
+		sorted[i].data.prevSlug = sorted[i + 1].id;
 		sorted[i].data.prevTitle = sorted[i + 1].data.title;
 	}
 
 	return sorted;
 }
 export type PostForList = {
-	slug: string;
+	id: string;
 	data: CollectionEntry<"posts">["data"];
 };
 export async function getSortedPostsList(): Promise<PostForList[]> {
@@ -45,7 +45,7 @@ export async function getSortedPostsList(): Promise<PostForList[]> {
 
 	// delete post.body
 	const sortedPostsList = sortedFullPosts.map((post) => ({
-		slug: post.slug,
+		id: post.id,
 		data: post.data,
 	}));
 

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -2,6 +2,14 @@ import I18nKey from "@i18n/i18nKey";
 import { i18n } from "@i18n/translation";
 import type { CollectionEntry } from "astro:content";
 
+/**
+ * 移除文件扩展名（.md, .mdx, .markdown）
+ * 用于将 Astro v5 Content Layer API 的 id 转换为 URL 友好的 slug
+ */
+export function removeFileExtension(id: string): string {
+	return id.replace(/\.(md|mdx|markdown)$/i, '');
+}
+
 export function pathsEqual(path1: string, path2: string) {
 	const normalizedPath1 = path1.replace(/^\/|\/$/g, "").toLowerCase();
 	const normalizedPath2 = path2.replace(/^\/|\/$/g, "").toLowerCase();
@@ -14,7 +22,9 @@ function joinUrl(...parts: string[]): string {
 }
 
 export function getPostUrlBySlug(slug: string): string {
-	return url(`/posts/${slug}/`);
+	// 移除文件扩展名（如 .md, .mdx 等）
+	const slugWithoutExt = removeFileExtension(slug);
+	return url(`/posts/${slugWithoutExt}/`);
 }
 
 export function getPostUrlByPermalink(permalink: string): string {
@@ -29,7 +39,7 @@ export function getPostUrl(post: CollectionEntry<"posts">): string {
 		return getPostUrlByPermalink(post.data.permalink);
 	}
 	// 否则使用默认的 slug 路径
-	return getPostUrlBySlug(post.slug);
+	return getPostUrlBySlug(post.id);
 }
 
 export function getTagUrl(tag: string): string {
@@ -48,11 +58,17 @@ export function getCategoryUrl(category: string | null): string {
 }
 
 export function getDir(path: string): string {
-	const lastSlashIndex = path.lastIndexOf("/");
+	// 移除文件扩展名
+	const pathWithoutExt = removeFileExtension(path);
+	const lastSlashIndex = pathWithoutExt.lastIndexOf("/");
 	if (lastSlashIndex < 0) {
 		return "/";
 	}
-	return path.substring(0, lastSlashIndex + 1);
+	return pathWithoutExt.substring(0, lastSlashIndex + 1);
+}
+
+export function getFileDirFromPath(filePath: string): string {
+	return filePath.replace(/^src\//, '').replace(/\/[^\/]+$/, '');
 }
 
 export function url(path: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ESNext",
 		"module": "ESNext",
-		"moduleResolution": "Node",
+		"moduleResolution": "bundler",
 		"jsx": "react-jsx",
 		"jsxImportSource": "react",
 		"baseUrl": ".",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other (please describe): Update to use new API

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
#172 

## Changes

<!-- Please describe the changes you made in this pull request. -->
Update content collections to use Content Loader API since Content Collections API (this template use this API) is considered as legacy feature (That API should be use normally but no longer recommended to use and no improvement from now).

## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
This PR based from CuteLeaf's PR on themself repo. https://github.com/CuteLeaf/Firefly/pull/100
