### PR TITLE
Style(page): 修复404页面中返回首页按钮被hover时使用未定义背景色的问题

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -35,7 +35,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
             <!-- 返回首页按钮 -->
             <a 
                 href="/" 
-                class="inline-flex items-center gap-2 px-6 py-3 bg-[var(--primary)] text-white rounded-[var(--radius-large)] hover:bg-[var(--primary-dark)] transition-colors duration-200 font-medium"
+                class="inline-flex items-center gap-2 px-6 py-3 bg-[var(--primary)] text-white rounded-[var(--radius-large)] hover:opacity-95 transition-colors transition-transform duration-200 font-medium"
             >
                 <Icon name="material-symbols:home" class="text-xl" />
                 {i18n(I18nKey.backToHome)}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [ ] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

Fix #215

## Changes

 - 修改`src/page/404.astro`中返回首页按钮的`hover:bg-[var(--primary-dark)]`为`hover:opacity-95`。建议在未来对其进行修改
 - 为`src/page/404.astro`中返回首页按钮添加`transition-transform`, 因为当前版本tailwindcss的`transition-colors`并不包含`transform`

## How To Test

在开发环境访问 http://localhost:4321/404/


## Additional Notes

请指出需要修改的地方，我会尽我所能修改。
**能不能在提交之前测试一下自己的修改在push啊喂，好多问题**
