### PR TITLE
refactor(calendar): 重构日历组件，异步数据加载并增强交互

### DIFF
--- a/src/components/widget/Calendar.astro
+++ b/src/components/widget/Calendar.astro
@@ -2,8 +2,8 @@
 import { siteConfig } from "../../config";
 import I18nKey from "../../i18n/i18nKey";
 import { i18n } from "../../i18n/translation";
-import { getSortedPosts } from "../../utils/content-utils";
 import WidgetLayout from "./WidgetLayout.astro";
+import { Icon } from "astro-icon/components";
 
 interface Props {
 	class?: string;
@@ -12,30 +12,6 @@ interface Props {
 
 const { class: className, style } = Astro.props;
 
-// 获取所有文章
-const posts = await getSortedPosts();
-
-// 创建文章日期映射（格式：YYYY-MM-DD -> 文章列表）
-const postDateMap = new Map<string, { id: string; title: string; published: Date }[]>();
-posts.forEach((post) => {
-	const date = new Date(post.data.published);
-	const dateKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
-	const existingPosts = postDateMap.get(dateKey) || [];
-	postDateMap.set(dateKey, [...existingPosts, {
-		id: post.id,
-		title: post.data.title,
-		published: post.data.published
-	}]);
-});
-
-// 序列化所有文章数据供客户端使用
-const allPostsData = posts.map((post) => ({
-	id: post.id,
-	title: post.data.title,
-	published: post.data.published.toISOString(),
-}));
-
-// 月份名称（使用 i18n）
 const monthNames = [
 	i18n(I18nKey.calendarJanuary),
 	i18n(I18nKey.calendarFebruary),
@@ -51,7 +27,6 @@ const monthNames = [
 	i18n(I18nKey.calendarDecember),
 ];
 
-// 星期名称（简写，使用 i18n）
 const weekDays = [
 	i18n(I18nKey.calendarMonday),
 	i18n(I18nKey.calendarTuesday),
@@ -62,185 +37,505 @@ const weekDays = [
 	i18n(I18nKey.calendarSunday),
 ];
 
-// 判断是否为中文环境
 const isChinese = siteConfig.lang.startsWith("zh");
 const yearSuffix = isChinese ? "年" : " ";
 ---
 
-<WidgetLayout id="calendar-widget" class={`hidden md:block ${className}`} style={style}>
-  <span slot="title-icon" id="calendar-widget-title" class="flex-1 text-left"></span>
-  
-  <div class="calendar-controls flex justify-between items-center mb-2">
-    <button id="prev-month" class="px-2 py-1 rounded bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)]">←</button>
-    <span id="calendar-month-year" class="font-medium"></span>
-    <button id="next-month" class="px-2 py-1 rounded bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)]">→</button>
-  </div>
+<WidgetLayout
+	id="calendar-widget"
+	class={`hidden md:block ${className}`}
+	style={style}
+>
+	<div class="flex justify-between items-center mb-4 relative">
+		<div
+			id="calendar-title-container"
+			class="flex-1 flex justify-center items-center cursor-pointer hover:bg-[var(--btn-plain-bg-hover)] py-2 rounded-lg transition-colors"
+		>
+			<span
+				id="calendar-title"
+				class="text-base font-bold text-neutral-900 dark:text-neutral-100 select-none"
+			></span>
+		</div>
 
-  <div class="calendar-container">
-    <!-- 星期标题 -->
-    <div class="weekdays grid grid-cols-7 gap-1 mb-2">
-      {weekDays.map(day => (
-        <div class="text-center text-xs text-neutral-500 dark:text-neutral-400 font-medium">
-          {day}
-        </div>
-      ))}
-    </div>
-    
-    <!-- 日历格子（由客户端动态生成） -->
-    <div class="calendar-grid grid grid-cols-7 gap-1" id="calendar-grid">
-    </div>
-    
-    <!-- 文章列表 -->
-    <div id="calendar-posts" class="mt-3">
-      <div class="border-t border-neutral-200 dark:border-neutral-700 mb-2" id="calendar-posts-divider" style="display: none;"></div>
-      <div class="flex flex-col gap-1" id="calendar-posts-list">
-      </div>
-    </div>
-  </div>
+		<div class="flex items-center gap-1 shrink-0 ml-2">
+			<button
+				id="back-to-today-btn"
+				class="p-1.5 rounded-md hover:bg-[var(--btn-plain-bg-hover)] text-[var(--primary)] transition-all invisible"
+				aria-label="Back to today"
+			>
+				<Icon
+					name="material-symbols:restart-alt-rounded"
+					class="text-xl"
+				/>
+			</button>
+
+			<button
+				id="prev-month-btn"
+				class="p-1.5 rounded-md hover:bg-[var(--btn-plain-bg-hover)] text-neutral-600 dark:text-neutral-400 hover:text-[var(--primary)] transition-colors"
+				aria-label="Previous month"
+			>
+				<Icon
+					name="material-symbols:chevron-left-rounded"
+					class="text-2xl"
+				/>
+			</button>
+
+			<button
+				id="next-month-btn"
+				class="p-1.5 rounded-md hover:bg-[var(--btn-plain-bg-hover)] text-neutral-600 dark:text-neutral-400 hover:text-[var(--primary)] transition-colors"
+				aria-label="Next month"
+			>
+				<Icon
+					name="material-symbols:chevron-right-rounded"
+					class="text-2xl"
+				/>
+			</button>
+		</div>
+	</div>
+
+	<div class="relative w-full overflow-hidden" style="min-height: 250px;">
+		<div id="calendar-view" class="w-full opacity-100">
+			<div class="grid grid-cols-7 gap-1 mb-2">
+				{
+					weekDays.map((day) => (
+						<div class="text-center text-xs text-neutral-500 dark:text-neutral-400 font-medium py-1">
+							{day}
+						</div>
+					))
+				}
+			</div>
+
+			<div id="calendar-grid" class="grid grid-cols-7 gap-1"></div>
+
+			<div id="calendar-posts" class="mt-4">
+				<div
+					class="h-[1px] w-full bg-neutral-200 dark:bg-neutral-700 mb-2 hidden"
+					id="calendar-posts-divider"
+				>
+				</div>
+				<div
+					class="flex flex-col gap-1 max-h-[150px] overflow-y-auto custom-scrollbar"
+					id="calendar-posts-list"
+				>
+				</div>
+			</div>
+		</div>
+
+		<div
+			id="selection-panel"
+			class="absolute inset-0 bg-[var(--card-bg)] z-10 flex flex-col hidden opacity-0 transition-opacity duration-200"
+		>
+			<div
+				id="selection-content"
+				class="w-full h-full overflow-y-auto custom-scrollbar p-2 grid gap-2 content-start"
+			>
+			</div>
+		</div>
+	</div>
 </WidgetLayout>
 
-<script is:inline define:vars={{ postDateMap: Object.fromEntries(postDateMap), allPostsData, monthNames, weekDays, yearSuffix }}>
-  let currentYear = new Date().getFullYear();
-  let currentMonth = new Date().getMonth();
+<script
+	is:inline
+	define:vars={{
+		monthNames,
+		yearSuffix,
+	}}
+>
+	let allPostsData = [];
+	const postDateMap = {};
+	const postsByMonth = {};
+	const stats = {
+		hasPostInYear: {},
+		hasPostInMonth: {},
+		minYear: new Date().getFullYear(),
+		maxYear: new Date().getFullYear() + 5,
+	};
 
-  function renderCalendar() {
-    const now = new Date();
-    const currentDate = (currentYear === now.getFullYear() && currentMonth === now.getMonth()) ? now.getDate() : null;
-    
-    // 更新 Widget 标题
-    const titleElement = document.getElementById('calendar-widget-title');
-    const monthYearElement = document.getElementById('calendar-month-year');
+	async function fetchCalendarData() {
+		try {
+			const res = await fetch("/api/calendar-data.json");
+			const data = await res.json();
 
-    if (titleElement) {
-    titleElement.textContent = `${currentYear}${yearSuffix}${monthNames[currentMonth]}`;
-    titleElement.classList.remove('text-neutral-500', 'dark:text-neutral-400');
-    titleElement.classList.add('text-black/90', 'dark:text-white/90', 'font-bold');
-    }
+			if (Array.isArray(data)) {
+				allPostsData = data;
+				processPostsData(allPostsData);
 
-   if (monthYearElement) {
-   monthYearElement.textContent = `${currentYear}${yearSuffix}${monthNames[currentMonth]}`;
-   monthYearElement.classList.remove('text-neutral-500', 'dark:text-neutral-400');
-   monthYearElement.classList.add('text-black/90', 'dark:text-white/90', 'font-bold');
-   }
+				const currentPostId = getCurrentPostId();
+				if (currentPostId) {
+					const matchedPost = allPostsData.find(
+						(p) => p.id === currentPostId,
+					);
+					if (matchedPost) {
+						const [y, m, d] = matchedPost.date.split("-");
+						currentYear = parseInt(y);
+						currentMonth = parseInt(m) - 1;
+					}
+				}
 
+				renderCalendar();
+			}
+		} catch (error) {
+			console.error("Failed to fetch calendar data:", error);
+		}
+	}
 
-    const firstDayOfMonth = (new Date(currentYear, currentMonth, 1).getDay() + 6) % 7;
-    const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
+	function processPostsData(posts) {
+		if (!posts || posts.length === 0) return;
 
-    const calendarGrid = document.getElementById('calendar-grid');
-    if (!calendarGrid) return;
-    
-    const calendarDays = [];
-    for (let i = 0; i < firstDayOfMonth; i++) {
-      calendarDays.push({ day: null, hasPost: false, count: 0, dateKey: "" });
-    }
-    for (let day = 1; day <= daysInMonth; day++) {
-      const dateKey = `${currentYear}-${String(currentMonth + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-      const posts = postDateMap[dateKey] || [];
-      calendarDays.push({
-        day,
-        hasPost: posts.length > 0,
-        count: posts.length,
-        dateKey
-      });
-    }
+		posts.forEach((post) => {
+			const [yStr, mStr, dStr] = post.date.split("-");
+			const year = parseInt(yStr);
+			const month = parseInt(mStr); // 1-12
 
-    calendarGrid.innerHTML = calendarDays.map(({day, hasPost, count, dateKey}) => {
-      const isToday = day === currentDate;
-      const classes = ["calendar-day aspect-square flex items-center justify-center rounded text-sm relative cursor-pointer"];
-      if (!day) classes.push("text-neutral-400 dark:text-neutral-600");
-      else if (!hasPost) classes.push("text-neutral-700 dark:text-neutral-300");
-      else classes.push("text-neutral-900 dark:text-neutral-100 font-bold");
-      if (isToday) classes.push("ring-2 ring-[var(--primary)]");
-      return `
-        <div
-          class="${classes.join(' ')}"
-          data-date="${dateKey}"
-          data-has-post="${hasPost}"
-        >
-          ${day || ''}
-          ${hasPost ? '<span class="absolute bottom-0 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-[var(--primary)]"></span>' : ''}
-          ${hasPost && count > 1 ? `<span class="absolute top-0 right-0 text-[10px] text-[var(--primary)] font-bold">${count}</span>` : ''}
-        </div>
-      `;
-    }).join('');
+			stats.hasPostInYear[year] = true;
+			stats.hasPostInMonth[`${year}-${month}`] = true;
+			if (year < stats.minYear) stats.minYear = year;
 
-    const currentMonthPosts = allPostsData.filter(post => {
-      const date = new Date(post.published);
-      return date.getFullYear() === currentYear && date.getMonth() === currentMonth;
-    });
+			const dateKey = post.date;
+			const monthKey = `${year}-${month - 1}`; // JS Month is 0-11
 
-    showMonthlyPosts(currentMonthPosts);
-    setupClickHandlers(currentMonthPosts);
-  }
+			if (!postDateMap[dateKey]) postDateMap[dateKey] = [];
+			postDateMap[dateKey].push(post);
 
-  function showMonthlyPosts(currentMonthPosts) {
-    const postsList = document.getElementById('calendar-posts-list');
-    const divider = document.getElementById('calendar-posts-divider');
-    if (postsList) {
-      postsList.innerHTML = currentMonthPosts.map(post => `
-        <a href="/posts/${post.id}/" class="block text-sm text-black/90 dark:text-white/90 hover:text-[var(--primary)] dark:hover:text-[var(--primary)] transition-colors truncate px-2 py-1 rounded hover:bg-[var(--btn-plain-bg-hover)]">
-          ${post.title}
-        </a>
-      `).join('');
-      if (divider) divider.style.display = currentMonthPosts.length > 0 ? 'block' : 'none';
-    }
-  }
+			if (!postsByMonth[monthKey]) postsByMonth[monthKey] = [];
+			postsByMonth[monthKey].push(post);
+		});
+	}
 
-  function setupClickHandlers(currentMonthPosts) {
-    const calendarDays = document.querySelectorAll('.calendar-day[data-date]');
-    const postsList = document.getElementById('calendar-posts-list');
-    const divider = document.getElementById('calendar-posts-divider');
-    let currentSelectedDay = null;
+	const now = new Date();
+	const todayYear = now.getFullYear();
+	const todayMonth = now.getMonth();
+	const todayDate = now.getDate();
 
-    calendarDays.forEach(dayElement => {
-      dayElement.addEventListener('click', () => {
-        const dateKey = dayElement.getAttribute('data-date');
-        const hasPost = dayElement.getAttribute('data-has-post') === 'true';
-        if (!hasPost || !dateKey) return;
+	let currentYear = todayYear;
+	let currentMonth = todayMonth;
+	let selectedDateKey = null;
+	let currentView = "day";
 
-        if (currentSelectedDay === dayElement) {
-          dayElement.classList.remove('bg-[var(--primary)]', 'bg-opacity-10');
-          currentSelectedDay = null;
-          showMonthlyPosts(currentMonthPosts);
-          return;
-        }
+	const dom = {
+		titleContainer: document.getElementById("calendar-title-container"),
+		title: document.getElementById("calendar-title"),
+		prevBtn: document.getElementById("prev-month-btn"),
+		nextBtn: document.getElementById("next-month-btn"),
+		backTodayBtn: document.getElementById("back-to-today-btn"),
+		calendarView: document.getElementById("calendar-view"),
+		selectionPanel: document.getElementById("selection-panel"),
+		selectionContent: document.getElementById("selection-content"),
+		grid: document.getElementById("calendar-grid"),
+		postsList: document.getElementById("calendar-posts-list"),
+		divider: document.getElementById("calendar-posts-divider"),
+	};
 
-        if (currentSelectedDay) currentSelectedDay.classList.remove('bg-[var(--primary)]', 'bg-opacity-10');
+	function getCurrentPostId() {
+		const path = window.location.pathname;
+		if (!allPostsData || allPostsData.length === 0) return null;
 
-        dayElement.classList.add('bg-[var(--primary)]', 'bg-opacity-10');
-        currentSelectedDay = dayElement;
+		const decodedPath = decodeURIComponent(path);
+		const normalizedPath = decodedPath.endsWith("/")
+			? decodedPath.slice(0, -1)
+			: decodedPath;
 
-        const posts = postDateMap[dateKey] || [];
-        if (posts.length > 0 && postsList) {
-          postsList.innerHTML = posts.map(post => `
-            <a href="/posts/${post.id}/" class="block text-sm text-black/90 dark:text-white/90 hover:text-[var(--primary)] dark:hover:text-[var(--primary)] transition-colors truncate px-2 py-1 rounded hover:bg-[var(--btn-plain-bg-hover)]">
-              ${post.title}
+		const matchedPost = allPostsData.find((post) => {
+			return normalizedPath.endsWith(`/${post.id}`);
+		});
+		return matchedPost ? matchedPost.id : null;
+	}
+
+	function init() {
+		renderCalendar();
+		setupEventListeners();
+
+		fetchCalendarData();
+	}
+
+	function setupEventListeners() {
+		dom.titleContainer.addEventListener("click", (e) => {
+			e.stopPropagation();
+			if (currentView === "day") showMonthPicker();
+			else if (currentView === "month") showYearPicker();
+			else closeSelectionPanel();
+		});
+
+		dom.prevBtn.addEventListener("click", () => {
+			currentMonth--;
+			if (currentMonth < 0) {
+				currentMonth = 11;
+				currentYear--;
+			}
+			renderCalendar();
+		});
+		dom.nextBtn.addEventListener("click", () => {
+			currentMonth++;
+			if (currentMonth > 11) {
+				currentMonth = 0;
+				currentYear++;
+			}
+			renderCalendar();
+		});
+
+		dom.backTodayBtn.addEventListener("click", () => {
+			currentYear = todayYear;
+			currentMonth = todayMonth;
+			selectedDateKey = null;
+			if (currentView !== "day") closeSelectionPanel();
+			else renderCalendar();
+		});
+
+		dom.grid.addEventListener("click", (e) => {
+			const cell = e.target.closest(".calendar-day");
+			if (!cell) return;
+
+			const dateKey = cell.getAttribute("data-date");
+
+			if (selectedDateKey === dateKey) selectedDateKey = null;
+			else selectedDateKey = dateKey;
+
+			renderCalendar();
+
+			if (selectedDateKey && postDateMap[selectedDateKey]) {
+				renderPostList(postDateMap[selectedDateKey]);
+			} else {
+				showMonthlyPosts();
+			}
+		});
+
+		dom.selectionContent.addEventListener("click", (e) => {
+			const monthItem = e.target.closest(".month-item");
+			const yearItem = e.target.closest(".year-item");
+
+			if (monthItem) {
+				e.stopPropagation();
+				currentMonth = parseInt(monthItem.getAttribute("data-month"));
+				closeSelectionPanel();
+			} else if (yearItem) {
+				e.stopPropagation();
+				currentYear = parseInt(yearItem.getAttribute("data-year"));
+				showMonthPicker();
+			}
+		});
+
+		document.addEventListener("click", (e) => {
+			if (currentView === "day") return;
+			const widget = document.getElementById("calendar-widget");
+			if (widget && !widget.contains(e.target)) {
+				closeSelectionPanel();
+			}
+		});
+	}
+
+	function updateHeader() {
+		dom.title.textContent = `${currentYear}${yearSuffix} ${monthNames[currentMonth]}`;
+
+		const isCurrentRealMonth =
+			currentYear === todayYear && currentMonth === todayMonth;
+		const shouldShowReset = !isCurrentRealMonth || selectedDateKey !== null;
+
+		if (shouldShowReset) dom.backTodayBtn.classList.remove("invisible");
+		else dom.backTodayBtn.classList.add("invisible");
+
+		const isDayView = currentView === "day";
+		dom.prevBtn.style.visibility = isDayView ? "visible" : "hidden";
+		dom.nextBtn.style.visibility = isDayView ? "visible" : "hidden";
+	}
+
+	function renderCalendar() {
+		updateHeader();
+
+		const firstDayOfMonth =
+			(new Date(currentYear, currentMonth, 1).getDay() + 6) % 7;
+		const daysInMonth = new Date(
+			currentYear,
+			currentMonth + 1,
+			0,
+		).getDate();
+
+		let html = "";
+		if (firstDayOfMonth > 0) {
+			html += `<div class="aspect-square"></div>`.repeat(firstDayOfMonth);
+		}
+
+		for (let day = 1; day <= daysInMonth; day++) {
+			const dateKey = `${currentYear}-${String(currentMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+
+			const posts = postDateMap[dateKey] || [];
+			const hasPost = posts.length > 0;
+			const count = posts.length;
+			const isToday =
+				currentYear === todayYear &&
+				currentMonth === todayMonth &&
+				day === todayDate;
+			const isSelected = selectedDateKey === dateKey;
+
+			let bgClass =
+				"hover:bg-[var(--btn-plain-bg-hover)] text-neutral-700 dark:text-neutral-300";
+			if (isSelected) {
+				bgClass = "bg-[var(--primary)] text-white shadow-md";
+			} else if (isToday) {
+				bgClass =
+					"text-[var(--primary)] font-bold bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]";
+			} else if (hasPost) {
+				bgClass =
+					"font-bold text-neutral-900 dark:text-neutral-100 hover:bg-[var(--btn-plain-bg-hover)]";
+			}
+
+			html += `
+                <div class="calendar-day aspect-square flex items-center justify-center rounded-md cursor-pointer relative transition-all duration-200 ${bgClass}"
+                    data-date="${dateKey}">
+                    ${day}
+                    ${hasPost && !isSelected ? `<span class="absolute bottom-1 w-1 h-1 rounded-full bg-[var(--primary)]"></span>` : ""}
+                    ${hasPost && count > 1 ? `<span class="absolute top-0.5 right-0.5 text-[9px] opacity-70 scale-75">${count}</span>` : ""}
+                </div>
+            `;
+		}
+		dom.grid.innerHTML = html;
+
+		if (selectedDateKey && postDateMap[selectedDateKey]) {
+			renderPostList(postDateMap[selectedDateKey]);
+		} else {
+			showMonthlyPosts();
+		}
+	}
+
+	function showMonthlyPosts() {
+		const key = `${currentYear}-${currentMonth}`; // Month is 0-11
+		const posts = postsByMonth[key] || [];
+		renderPostList(posts);
+	}
+
+	function renderPostList(posts) {
+		if (!dom.postsList) return;
+
+		if (posts.length === 0) {
+			dom.divider.classList.add("hidden");
+			dom.postsList.innerHTML = "";
+			return;
+		}
+		dom.divider.classList.remove("hidden");
+
+		const currentPostId = getCurrentPostId();
+
+		const listHtml = posts
+			.map((post) => {
+				const [y, m, d] = post.date.split("-");
+				const dateStr = `${parseInt(m)}-${parseInt(d)}`;
+				const isCurrentPost = post.id === currentPostId;
+
+				let containerClass =
+					"flex items-center justify-between text-sm transition-colors px-2 py-2 rounded-lg group border border-transparent";
+				let titleClass = "truncate flex-1 font-bold transition-colors";
+				let dateClass =
+					"text-xs ml-2 whitespace-nowrap transition-colors";
+
+				if (isCurrentPost) {
+					containerClass +=
+						" bg-[var(--primary)]/10 text-[var(--primary)] border-[var(--primary)]/10";
+					dateClass += " text-[var(--primary)]/80";
+				} else {
+					containerClass +=
+						" text-neutral-700 dark:text-neutral-300 hover:text-[var(--primary)] dark:hover:text-[var(--primary)] hover:bg-[var(--btn-plain-bg-hover)]";
+					dateClass +=
+						" text-neutral-400 group-hover:text-[var(--primary)]/70";
+				}
+
+				return `
+            <a href="/posts/${post.id}/" class="${containerClass}">
+                <span class="${titleClass}">${post.title}</span>
+                <span class="${dateClass}">${dateStr}</span>
             </a>
-          `).join('');
-          if (divider) divider.style.display = 'block';
-        }
-      });
-    });
-  }
+        `;
+			})
+			.join("");
 
-  document.getElementById('prev-month')?.addEventListener('click', () => {
-    currentMonth--;
-    if (currentMonth < 0) { currentMonth = 11; currentYear--; }
-    renderCalendar();
-  });
+		dom.postsList.innerHTML = listHtml;
+	}
 
-  document.getElementById('next-month')?.addEventListener('click', () => {
-    currentMonth++;
-    if (currentMonth > 11) { currentMonth = 0; currentYear++; }
-    renderCalendar();
-  });
+	function showMonthPicker() {
+		currentView = "month";
+		updateHeader();
+		dom.selectionPanel.classList.remove("hidden");
+		requestAnimationFrame(() => {
+			dom.selectionPanel.classList.remove("opacity-0");
+		});
 
-  renderCalendar();
+		dom.selectionContent.className =
+			"w-full h-full p-4 grid grid-cols-3 gap-3 content-center";
+		let html = "";
+		monthNames.forEach((name, index) => {
+			const isCurrentMonth = index === currentMonth;
+			const hasPost = stats.hasPostInMonth[`${currentYear}-${index + 1}`];
+
+			let cls =
+				"month-item cursor-pointer rounded-lg flex flex-col items-center justify-center p-2 transition-all hover:bg-[var(--btn-plain-bg-hover)] relative border border-transparent";
+			if (isCurrentMonth)
+				cls +=
+					" border-[var(--primary)] text-[var(--primary)] bg-[var(--primary)]/5";
+			else cls += " text-neutral-700 dark:text-neutral-300";
+
+			html += `
+                <div class="${cls}" data-month="${index}">
+                    <span class="text-sm font-bold">${name}</span>
+                    ${hasPost ? `<span class="w-1 h-1 rounded-full bg-[var(--primary)] mt-1"></span>` : `<span class="w-1 h-1 mt-1"></span>`}
+                </div>
+             `;
+		});
+		dom.selectionContent.innerHTML = html;
+	}
+
+	function showYearPicker() {
+		currentView = "year";
+		updateHeader();
+		dom.selectionContent.className =
+			"w-full h-full p-2 grid grid-cols-4 gap-2 content-start overflow-y-auto";
+		let html = "";
+
+		for (let y = stats.minYear; y <= stats.maxYear; y++) {
+			const isCurrent = y === currentYear;
+			const hasPost = stats.hasPostInYear[y];
+			let cls =
+				"year-item cursor-pointer rounded-lg flex flex-col items-center justify-center py-3 transition-all hover:bg-[var(--btn-plain-bg-hover)] relative border border-transparent";
+			if (isCurrent)
+				cls +=
+					" border-[var(--primary)] text-[var(--primary)] bg-[var(--primary)]/5";
+			else cls += " text-neutral-700 dark:text-neutral-300";
+
+			html += `
+                <div class="${cls}" data-year="${y}" id="year-${y}">
+                    <span class="text-sm font-bold">${y}</span>
+                     ${hasPost ? `<span class="w-1.5 h-1.5 rounded-full bg-[var(--primary)] mt-1"></span>` : `<span class="w-1.5 h-1.5 mt-1"></span>`}
+                </div>
+            `;
+		}
+		dom.selectionContent.innerHTML = html;
+		setTimeout(() => {
+			const el = document.getElementById(`year-${currentYear}`);
+			if (el) el.scrollIntoView({ block: "center", behavior: "smooth" });
+		}, 50);
+	}
+
+	function closeSelectionPanel() {
+		dom.selectionPanel.classList.add("opacity-0");
+		setTimeout(() => {
+			dom.selectionPanel.classList.add("hidden");
+			currentView = "day";
+			renderCalendar();
+		}, 200);
+	}
+
+	init();
 </script>
 
 <style>
-  .calendar-day { transition: all 0.2s ease; min-height: 32px; }
-  .calendar-day[data-has-post="true"]:hover { transform: translateY(-2px); }
+	.custom-scrollbar::-webkit-scrollbar {
+		width: 4px;
+	}
+	.custom-scrollbar::-webkit-scrollbar-track {
+		background: transparent;
+	}
+	.custom-scrollbar::-webkit-scrollbar-thumb {
+		background-color: rgba(156, 163, 175, 0.5);
+		border-radius: 2px;
+	}
+	.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+		background-color: rgba(156, 163, 175, 0.8);
+	}
 </style>
-

--- a/src/pages/api/calendar-data.json.ts
+++ b/src/pages/api/calendar-data.json.ts
@@ -1,0 +1,24 @@
+import { getSortedPosts } from "../../utils/content-utils";
+
+export async function GET() {
+	const posts = await getSortedPosts();
+
+	const allPostsData = posts.map((post) => {
+		const date = new Date(post.data.published);
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, "0");
+		const day = String(date.getDate()).padStart(2, "0");
+
+		return {
+			id: post.id,
+			title: post.data.title,
+			date: `${year}-${month}-${day}`,
+		};
+	});
+
+	return new Response(JSON.stringify(allPostsData), {
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+}


### PR DESCRIPTION
- 性能优化：将文章数据移至 `/api/calendar-data.json` 异步加载，减小 HTML 体积。
- 交互升级：点击标题可呼出年月选择面板，支持快速跳转。
- 功能新增：增加“回到今天”按钮；支持自动定位并高亮当前阅读的文章。
- UI 优化：引入图标替代文本按钮，优化文章列表滚动及选中样式。

## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [ ] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [ ] I have checked to ensure that this Pull Request is not for personal changes.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->

### 标题：重构日历组件：异步数据加载与交互体验升级

#### 变更摘要
本 PR 对 Calendar 组件进行了彻底重构，主要包含以下改进：

**架构调整 (性能)**
- 不再将所有文章数据在服务端构建时直接写入 HTML。
- 新增 calendar-data.json.ts 端点，改为客户端异步 Fetch 数据，显著降低首屏载入体积。

**交互增强 (功能)**
- **年月选择器**：点击日历标题可切换至“月份”或“年份”选择面板，解决跨度大时难以跳转的问题。
- **当前定位**：进入文章页面时，日历会自动跳转至该文章的年份/月份并高亮显示。
- **“back to today”按钮**：新增快捷复位按钮。

**UI/UX 改进**
- 使用 Icon 图标替换纯文本箭头。
- 文章列表区域增加滚动条限制高度，优化视觉布局。

#### 新增文件
- `src/pages/api/calendar-data.json.ts`

## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
