### PR TITLE
fix: 修复加密内容解密后的显示和脚本执行问题

### DIFF
--- a/src/components/PasswordProtection.astro
+++ b/src/components/PasswordProtection.astro
@@ -189,6 +189,15 @@ const { encryptedContent } = Astro.props;
 		width: 100% !important;
 	}
 
+	/* Hide encrypted components initially */
+	:global(.encrypted-hidden) {
+		display: none !important;
+	}
+
+	:global(.encrypted-hidden-wrapper.encrypted-hidden) {
+		display: none !important;
+	}
+
 	@media (min-width: 769px) {
 		.password-input-group {
 			flex-wrap: nowrap;
@@ -388,8 +397,40 @@ const { encryptedContent } = Astro.props;
 
 				contentDiv.innerHTML = realContent;
 
+				// 手动执行解密后的 script 标签
+				const scripts = contentDiv.querySelectorAll("script");
+				const scriptPromises = Array.from(scripts).map((script) => {
+					return new Promise((resolve) => {
+						const newScript = document.createElement("script");
+						if (script.type) {
+							newScript.type = script.type;
+						}
+						newScript.textContent = script.textContent;
+						newScript.onload = resolve;
+						newScript.onerror = resolve;
+						script.parentNode?.replaceChild(newScript, script);
+						// 如果脚本已经加载（内联脚本），立即 resolve
+						if (!newScript.src) {
+							resolve(undefined);
+						}
+					});
+				});
+
+				// 等待所有脚本执行完成
+				await Promise.all(scriptPromises);
+
 				protectionDiv.style.display = "none";
 				contentDiv.style.display = "block";
+
+				// 显示分享组件和版权信息
+				const shareComponent = document.getElementById("share-component");
+				const licenseComponent = document.getElementById("license-component");
+				if (shareComponent) {
+					shareComponent.classList.remove("encrypted-hidden");
+				}
+				if (licenseComponent) {
+					licenseComponent.classList.remove("encrypted-hidden");
+				}
 
 				sessionStorage.setItem(
 					"page-password-" + window.location.pathname,
@@ -397,7 +438,7 @@ const { encryptedContent } = Astro.props;
 				);
 
 				// 触发后续处理
-				setTimeout(() => {
+				setTimeout(async () => {
 					const tocElement =
 						document.querySelector("table-of-contents");
 					if (
@@ -432,6 +473,13 @@ const { encryptedContent } = Astro.props;
 
 					window.dispatchEvent(new Event("scroll"));
 					window.dispatchEvent(new Event("resize"));
+
+					// 触发 mermaid 重新渲染
+					if (typeof window.renderMermaidDiagrams === "function") {
+						// 等待一小段时间确保 DOM 完全更新
+						await new Promise(resolve => setTimeout(resolve, 100));
+						window.renderMermaidDiagrams();
+					}
 				}, 100);
 			} catch (error) {
 				console.error(i18nDecryptionError, error);

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -297,7 +297,7 @@ const jsonLd = {
             }
 
             {shareConfig.enable && (
-                <div class="p-6 bg-[var(--license-block-bg)] rounded-xl mb-6 onload-animation">
+                <div id="share-component" class:list={["p-6 bg-[var(--license-block-bg)] rounded-xl mb-6 onload-animation", { "encrypted-hidden": isEncrypted }]}>
                     <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
                         <div class="flex items-center gap-3 flex-1">
                             <div class="flex items-center justify-center h-12 w-12 rounded-lg bg-[var(--enter-btn-bg)]">
@@ -333,7 +333,8 @@ const jsonLd = {
             )}
 
             {licenseConfig.enable && (
-                <License
+                <div id="license-component" class:list={["encrypted-hidden-wrapper", { "encrypted-hidden": isEncrypted }]}>
+                    <License
                     title={entry.data.title}
                     id={entry.id}
                     pubDate={entry.data.published}
@@ -343,6 +344,7 @@ const jsonLd = {
                     licenseUrl={entry.data.licenseUrl}
                     class="mb-6 rounded-xl license-container onload-animation"
                 />
+                </div>
             )}
         </div>
     </div>

--- a/src/plugins/mermaid-render-script.js
+++ b/src/plugins/mermaid-render-script.js
@@ -1,6 +1,10 @@
 (() => {
 	// 单例模式：检查是否已经初始化过
 	if (window.mermaidInitialized) {
+		// 如果已经初始化过，只确保 renderMermaidDiagrams 函数可用
+		if (typeof window.renderMermaidDiagrams !== "function") {
+			window.renderMermaidDiagrams = renderMermaidDiagrams;
+		}
 		return;
 	}
 
@@ -491,6 +495,9 @@
 			// 加载并初始化 Mermaid
 			await loadMermaid();
 			await initializeMermaid();
+
+			// 将 renderMermaidDiagrams 暴露到全局作用域，以便在解密后调用
+			window.renderMermaidDiagrams = renderMermaidDiagrams;
 		} catch (error) {
 			console.error("Failed to initialize Mermaid system:", error);
 		}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->
确保解密后正确显示分享组件和版权信息，并处理内联脚本的执行。同时将 mermaid 渲染函数暴露到全局以便解密后调用，并添加相关样式控制加密内容的初始隐藏状态。

## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
