### PR TITLE
docs: Fix broken README language links and image paths

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.9.2-blue)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-![Mizuki Preview](../README.webp)
+![Mizuki Preview](./README.webp)
 
 <table>
   <tr>

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ A modern, feature-rich static blog template built with [Astro](https://astro.bui
 🌏 README Languages
 [**English**](./README.md) /
 [**中文**](./README.zh.md) /
-[**日本語**](./docs/README.ja.md) /
-[**中文繁体**](./docs/README.tw.md) /
+[**日本語**](./README.ja.md) /
+[**中文繁体**](./README.tw.md) /
 
 ![Configuration](configuration.svg)
 

--- a/README.tw.md
+++ b/README.tw.md
@@ -5,18 +5,18 @@
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.9.2-blue)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-![Mizuki Preview](../README.webp)
+![Mizuki Preview](./README.webp)
 
 <table>
   <tr>
-    <td><img alt="" src="image/1.webp"></td>
-    <td><img alt="" src="image/2.webp"></td>
-    <td><img alt="" src="image/3.webp"></td>
+    <td><img alt="" src="docs/image/1.webp"></td>
+    <td><img alt="" src="docs/image/2.webp"></td>
+    <td><img alt="" src="docs/image/3.webp"></td>
   <tr>
   <tr>
-    <td><img alt="" src="image/4.webp"></td>
-    <td><img alt="" src="image/5.webp"></td>
-    <td><img alt="" src="image/6.webp"></td>
+    <td><img alt="" src="docs/image/4.webp"></td>
+    <td><img alt="" src="docs/image/5.webp"></td>
+    <td><img alt="" src="docs/image/6.webp"></td>
   <tr>
 </table>
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
N/A (fixes broken README links/assets)

## Changes

<!-- Please describe the changes you made in this pull request. -->
- Fixed README language switch links that previously pointed to non-existent paths (404).
- Fixed image references in `README.ja.md` and `README.tw.md`:
 - Updated `/image/x.webp` to `docs/image/x.webp` in both TW and JA README
 - Removed the incorrect extra dot in the relative image path (e.g. `../README.webp`)


## How To Test

<!-- Please describe how you tested your changes. -->
1. Open the repo README and click the Japanese / Traditional Chinese links — verify they no longer return 404.
2. Open `README.ja.md` and `README.tw.md` — verify images render correctly on GitHub.


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
I understand the JA/TW pages/links might be intentionally left incomplete while the documentation is still being finalized.  
However, since the language navigation is already present (and working) for the other README translations, I went ahead and fixed the JA/TW links and asset paths so the existing pages render correctly instead of leading to 404/broken images.
