### PR TITLE
fix: 隐藏playList滚动条

### DIFF
--- a/src/components/widget/MusicPlayer.svelte
+++ b/src/components/widget/MusicPlayer.svelte
@@ -678,7 +678,7 @@ onDestroy(() => {
                     <Icon icon="material-symbols:close" class="text-lg" />
                 </button>
             </div>
-            <div class="playlist-content overflow-y-auto max-h-80">
+            <div class="playlist-content overflow-y-auto max-h-80 hide-scrollbar">
                 {#each playlist as song, index}
                     <div class="playlist-item flex items-center gap-3 p-3 hover:bg-[var(--btn-plain-bg-hover)] cursor-pointer transition-colors"
                          class:bg-[var(--btn-plain-bg)]={index === currentIndex}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

musicPanel滚动条未隐藏 https://github.com/matsuzaka-yuki/Mizuki/issues/315
<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

为playlist-content  增加  hide-scrollbar

## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<img width="395" height="472" alt="image" src="https://github.com/user-attachments/assets/42b8a028-1563-4f70-8872-13dc947d4821" />



## Additional Notes

