### PR TITLE
fix: closable 配置无效，关闭按钮无法生效

### DIFF
--- a/src/components/widget/Announcement.astro
+++ b/src/components/widget/Announcement.astro
@@ -60,10 +60,12 @@ const style = Astro.props.style;
 <script>
     function closeAnnouncement() {
         // 通过data-id属性找到整个widget-layout元素
-        const widgetLayout = document.querySelector('widget-layout[data-id="announcement"]') as HTMLElement;
-        if (widgetLayout) {
-            // 隐藏整个widget-layout元素
-            widgetLayout.style.display = 'none';
+        const widgetLayouts = document.querySelectorAll('widget-layout[data-id="announcement"]');
+        if (widgetLayouts.length > 0) {
+            widgetLayouts.forEach((widget) => {
+                // 隐藏整个widget-layout元素
+                (widget as HTMLElement).style.display = 'none';
+            });
             // 保存关闭状态到localStorage
             localStorage.setItem('announcementClosed', 'true');
         }
@@ -71,9 +73,12 @@ const style = Astro.props.style;
 
     // 页面加载时检查是否已关闭
     document.addEventListener('DOMContentLoaded', function() {
-        const widgetLayout = document.querySelector('widget-layout[data-id="announcement"]') as HTMLElement;
-        if (widgetLayout && localStorage.getItem('announcementClosed') === 'true') {
-            widgetLayout.style.display = 'none';
+        const widgetLayouts = document.querySelectorAll('widget-layout[data-id="announcement"]');
+
+        if (widgetLayouts.length > 0 && localStorage.getItem('announcementClosed') === 'true') {
+            widgetLayouts.forEach((widget) => {
+                (widget as HTMLElement).style.display = 'none';
+            });
         }
     });
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
[Bug]: 公告组件 closable 配置无效，关闭按钮无法生效 #338 

## Changes

<!-- Please describe the changes you made in this pull request. -->
closeAnnouncement中查询widget换用querySelectorAll，依旧是 桌面端和手机端存在两个公告，按钮事件只隐藏了其中一个，而表现出的 关闭按钮无法生效

## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
<img width="1751" height="625" alt="image" src="https://github.com/user-attachments/assets/a9dad4e2-5a4b-4401-bcb8-413b6e02946f" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
