### PR TITLE
feat: 为文章添加评论开关控制功能

### DIFF
--- a/_frontmatter.json
+++ b/_frontmatter.json
@@ -57,6 +57,11 @@
 					"type": "boolean"
 				},
 				{
+					"title": "comment",
+					"name": "comment",
+					"type": "boolean"
+				},
+				{
 					"title": "language",
 					"name": "language",
 					"type": "string"

--- a/src/components/comment/index.astro
+++ b/src/components/comment/index.astro
@@ -8,7 +8,7 @@ interface Props {
 	post: CollectionEntry<"posts">;
 }
 
-const { id, data: _data } = Astro.props.post;
+const { id, data } = Astro.props.post;
 
 const slug = removeFileExtension(id);
 const path = `/posts/${slug}`;
@@ -18,8 +18,10 @@ let commentService = "";
 if (commentConfig?.enable && commentConfig?.twikoo) {
 	commentService = "twikoo";
 }
+
+const commentEnabled = data.comment ?? true;
 ---
-{commentConfig?.enable && (
+{commentConfig?.enable && commentEnabled && (
   <div class="card-base p-6 mb-4">
     {commentService === 'twikoo' && <Twikoo path={path} />}
     {commentService === '' && null}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,6 @@
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
-import { z } from 'astro/zod';
+import { z } from "astro/zod";
 
 const postsCollection = defineCollection({
 	loader: glob({ pattern: "**/*.md", base: "./src/content/posts" }),
@@ -15,6 +15,7 @@ const postsCollection = defineCollection({
 		category: z.string().optional().nullable().default(""),
 		lang: z.string().optional().default(""),
 		pinned: z.boolean().optional().default(false),
+		comment: z.boolean().optional().default(true),
 		priority: z.number().optional(),
 		author: z.string().optional().default(""),
 		sourceLink: z.string().optional().default(""),


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
- resolved #343

## Changes

<!-- Please describe the changes you made in this pull request. -->
- 在文章 frontmatter 中新增 `comment` 布尔字段，默认为 true
- 更新内容配置架构以包含该字段
- 修改评论组件，仅在全局评论启用且文章未显式禁用时显示

## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
