### PR TITLE
fix: 重新进入网站保留音量设置

### DIFF
--- a/src/components/widget/MusicPlayer.svelte
+++ b/src/components/widget/MusicPlayer.svelte
@@ -32,10 +32,10 @@ let showPlaylist = false;
 // 当前播放时间，默认为 0
 let currentTime = 0;
 // 歌曲总时长，默认为 0
-let duration = 0;git add .
+let duration = 0;
 
 // localStorage 存储音量
-const STORAGE_KEY_VOLUME = 'music-player-volume';g
+const STORAGE_KEY_VOLUME = 'music-player-volume';
 
 // 音量，默认为 0.7
 let volume = 0.7;


### PR DESCRIPTION
## Type of change

- [√] Bug fix (a non-breaking change that fixes an issue)

## Checklist

- [√] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [√] I have checked to ensure that this Pull Request is not for personal changes.
- [√] I have performed a self-review of my own code.
- [√] My changes generate no new warnings.

## Changes

- 重新进入网站时从LocalStorage读取并应用上次保存的音量，无需每次手动调整

## How To Test

1. 打开音乐播放器，调整音量到任意值(如50%)
2. 重新进入网站，音量依旧为50%

## Related Issue
Closes #354