### PR TITLE
fix(pio): avoid hidden class conflict so reopen icon shows

### DIFF
--- a/public/pio/static/pio.css
+++ b/public/pio/static/pio.css
@@ -32,16 +32,16 @@
 	background: url(avatar.jpg) center / contain;
 }
 
-.pio-container.hidden .pio-show {
+.pio-container.pio-hidden .pio-show {
 	display: block;
 }
-.pio-container.hidden .pio-show:hover {
+.pio-container.pio-hidden .pio-show:hover {
 	transform: translateX(0.5em);
 }
 
-.pio-container.hidden #pio,
-.pio-container.hidden .pio-action,
-.pio-container.hidden .pio-dialog {
+.pio-container.pio-hidden #pio,
+.pio-container.pio-hidden .pio-action,
+.pio-container.pio-hidden .pio-dialog {
 	display: none;
 }
 

--- a/public/pio/static/pio.js
+++ b/public/pio/static/pio.js
@@ -335,11 +335,11 @@ var Paul_Pio = function (prop) {
 			current.body.style.bottom = null;
 		}
 
-		current.body.classList.add("hidden");
+		current.body.classList.add("pio-hidden");
 		elements.dialog.classList.remove("active");
 
 		elements.show.onclick = () => {
-			current.body.classList.remove("hidden");
+			current.body.classList.remove("pio-hidden");
 			localStorage.setItem("posterGirl", "1");
 
 			this.init();


### PR DESCRIPTION
## Summary
Fix the Pio widget reopen behavior after closing.

The widget used a generic `hidden` class for its hidden state.  
In this theme, `hidden` conflicts with global utility styles and hides the whole container, so the reopen trigger icon is not visible.

## Changes
- Replace hidden-state class from `hidden` to `pio-hidden` in:
  - `public/pio/static/pio.css`
  - `public/pio/static/pio.js`
- Keep existing behavior unchanged:
  - Close button still hides the model
  - Reopen button (`.pio-show`) is visible and works as expected

## Why
Avoid class name collision with global styles and restore expected reopen UX.