### PR TITLE
修复了相册中，column为2时显示为3列的问题

### DIFF
--- a/src/pages/albums/[id]/index.astro
+++ b/src/pages/albums/[id]/index.astro
@@ -142,31 +142,52 @@ if (!album) {
   }
   
   .grid-layout[data-columns="2"] {
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
   }
   
   .grid-layout[data-columns="3"] {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
   }
   
   .grid-layout[data-columns="4"] {
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(4, 1fr);
   }
   
-  .masonry-layout {
+  .masonry-layout[data-columns="2"] {
     columns: 2;
     column-gap: 1rem;
   }
   
-  @media (min-width: 768px) {
-    .masonry-layout {
-      columns: 3;
+  .masonry-layout[data-columns="3"] {
+    columns: 3;
+    column-gap: 1rem;
+  }
+  
+  .masonry-layout[data-columns="4"] {
+    columns: 4;
+    column-gap: 1rem;
+  }
+  
+  /* 响应式调整 */
+  @media (max-width: 768px) {
+    .grid-layout[data-columns="3"],
+    .grid-layout[data-columns="4"] {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    
+    .masonry-layout[data-columns="3"],
+    .masonry-layout[data-columns="4"] {
+      columns: 2;
     }
   }
   
-  @media (min-width: 1280px) {
-    .masonry-layout[data-columns="4"] {
-      columns: 4;
+  @media (max-width: 480px) {
+    .grid-layout {
+      grid-template-columns: 1fr !important;
+    }
+    
+    .masonry-layout {
+      columns: 1 !important;
     }
   }
   


### PR DESCRIPTION
# 不知道这个修改是否有效
这个是我对之前版本修复的问题，可能不和新版本兼容
修改的版本提交为：
Merge pull request [#398](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from sakuhanachan/astro6

Upgrade Astro to version 6

# 修改了index.astro
 **问题原因**：原代码使用 `auto-fit` 导致列数动态调整，无法准确匹配设置的 columns 值
- **解决方案**：将动态列数改为固定列数，确保 columns 配置直接生效
- **验证方法**：测试 columns=2、3、4 均正常显示

> [!WARNING]
我用新版本本地测试的时候，示例相册columns为3列，但是我这边看到的是1列。修改后也还是显示1列
于是尝试将我自己的版本合并master的时候出现各种冲突，但我太菜了搞不明白。
由于本人水平有限，没有对上述新版本问题继续研究，关闭了之前的pr
然后我看到之前pr作者居然回复我了。想了想，还是再交一次pr