### PR TITLE
fix(profile): 修复页面访问统计在桌面端不显示的问题

### DIFF
--- a/src/components/widgets/profile/Profile.astro
+++ b/src/components/widgets/profile/Profile.astro
@@ -72,14 +72,14 @@ import { i18n } from "../../../i18n/translation";
     }
 
     async function fetchSiteStats(isRetry = false) {
-        const container = document.querySelector('.umami-stats-container');
-        
+        const containers = document.querySelectorAll('.umami-stats-container');
+
         // oddmisc 未加载则等待重试
         if (!window.oddmisc) {
             if (!isRetry) {
                 setTimeout(() => fetchSiteStats(true), 500);
             } else {
-                container?.classList.add('hidden');
+                containers.forEach(c => c.classList.add('hidden'));
             }
             return;
         }
@@ -91,23 +91,27 @@ import { i18n } from "../../../i18n/translation";
 
             // 数据为 0 时隐藏
             if (pageViews === 0 && visits === 0) {
-                container?.classList.add('hidden');
+                containers.forEach(c => c.classList.add('hidden'));
                 return;
             }
 
-            container?.classList.remove('hidden');
+            containers.forEach(c => c.classList.remove('hidden'));
             document.querySelectorAll('.site-stats-display').forEach(el => {
                 el.textContent = generateStatsText(pageViews, visits);
             });
         } catch (error) {
             console.error('Error fetching site stats:', error);
-            container?.classList.add('hidden');
+            containers.forEach(c => c.classList.add('hidden'));
         }
     }
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', () => fetchSiteStats());
-    } else {
-        fetchSiteStats();
+    // 避免多个 Profile 实例重复请求
+    if (!window.__siteStatsFetching) {
+        window.__siteStatsFetching = true;
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => fetchSiteStats());
+        } else {
+            fetchSiteStats();
+        }
     }
 </script>


### PR DESCRIPTION
querySelector 只匹配第一个 .umami-stats-container（移动端隐藏的侧栏）， 桌面端的统计容器 hidden 永远不会被移除。改用 querySelectorAll 操作所有实例， 并添加去重标志避免多个 Profile 实例重复发起 API 请求。

## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
