### PR TITLE
fix: CardTOC 的一级目录徽章始终为数字, 尽管 useJapaneseBadge 已启用

### DIFF
--- a/src/components/widgets/card-toc/CardTOC.astro
+++ b/src/components/widgets/card-toc/CardTOC.astro
@@ -8,6 +8,7 @@
 import "@/styles/toc.css";
 
 import type { MarkdownHeading } from "astro";
+import { siteConfig } from "@/config";
 
 import I18nKey from "../../../i18n/i18nKey";
 import { i18n } from "../../../i18n/translation";
@@ -20,6 +21,7 @@ interface Props {
 }
 
 const { class: className, style } = Astro.props;
+const useJapaneseBadge = siteConfig.toc.useJapaneseBadge;
 ---
 
 <WidgetLayout
@@ -28,7 +30,10 @@ const { class: className, style } = Astro.props;
 	class={"group " + (className || "")}
 	style={style}
 >
-	<div data-card-toc-root>
+	<div
+		data-card-toc-root
+		data-japanese-badge={String(useJapaneseBadge)}
+	>
 		<div class="toc-scroll-container">
 			<div class="toc-content" data-card-toc-content></div>
 		</div>
@@ -78,9 +83,13 @@ const { class: className, style } = Astro.props;
 				existingManager.cleanup();
 			}
 
+			const useJapaneseBadge =
+				root.dataset.japaneseBadge === "true";
+
 			const manager = new TOCManager({
 				contentElement: tocContent,
 				maxLevel: 3,
+				useJapaneseBadge,
 				scrollOffset: 80,
 			});
 

--- a/src/utils/tocManager.ts
+++ b/src/utils/tocManager.ts
@@ -6,12 +6,14 @@
 
 import I18nKey from "../i18n/i18nKey";
 import { i18n } from "../i18n/translation";
+import { JAPANESE_KATAKANA } from "../components/features/toc/utils/japanese-katakana";
 
 export interface TOCConfig {
 	contentId?: string;
 	contentElement?: HTMLElement;
 	maxLevel?: number;
 	scrollOffset?: number;
+	useJapaneseBadge?: boolean;
 }
 
 export class TOCManager {
@@ -23,12 +25,14 @@ export class TOCManager {
 	private contentId: string | null;
 	private contentElement: HTMLElement | null;
 	private scrollOffset: number;
+	private useJapaneseBadge: boolean;
 
 	constructor(config: TOCConfig) {
 		this.contentId = config.contentId ?? null;
 		this.contentElement = config.contentElement ?? null;
 		this.maxLevel = config.maxLevel || 3;
 		this.scrollOffset = config.scrollOffset || 80;
+		this.useJapaneseBadge = config.useJapaneseBadge ?? false;
 	}
 
 	/**
@@ -110,6 +114,12 @@ export class TOCManager {
 
 	private generateBadgeContent(depth: number, heading1Count: number): string {
 		if (depth === this.minDepth) {
+			if (
+				this.useJapaneseBadge &&
+				heading1Count - 1 < JAPANESE_KATAKANA.length
+			) {
+				return JAPANESE_KATAKANA[heading1Count - 1];
+			}
 			return heading1Count.toString();
 		}
 		if (depth === this.minDepth + 1) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->
为 `CardTOC.astro` 增加了日语徽章支持，用于一级目录项显示。

### 变更内容:

#### `CardTOC.astro` 参数传递
  - 读取 `siteConfig.toc.useJapaneseBadge`
  - 将 `useJapaneseBadge` 传入 `TOCManager`
  - 不调整深度行为  (保持 maxLevel: 3 不变)
  - `TOCManager` 支持日语徽章

#### `tocManager.ts`
  - 在 `TOCConfig` 中新增可选参数 `useJapaneseBadge`
  - 当开启时，一级目录徽章使用 `JAPANESE_KATAKANA` 渲染
  - 关闭或超出片假名范围时，回退为数字徽章

### 变更原因:
此前 `CardTOC` 的一级目录徽章始终为数字。尽管  `useJapaneseBadge` 已在 `src/config.ts` 启用。该 PR 让 `CardTOC` 能根据配置切换为日语片假名徽章，同时不影响现有目录深度逻辑。

## How To Test

<!-- Please describe how you tested your changes. -->

- `siteConfig.toc.useJapaneseBadge` = true：`CardTOC.astro` 一级目录徽章显示片假名

- `siteConfig.toc.useJapaneseBadge` = false：`CardTOC.astro` 一级目录徽章保持数字

<br>

二级及更深层级（点状徽章）保持原有行为不变

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
<img width="842" height="787" alt="image" src="https://github.com/user-attachments/assets/baa8d3cf-a9dd-47fc-a30a-4c2dc5f3a6e7" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
