### PR TITLE
fix(toc): improve sidebar toc scroll bounds and smoothness

### DIFF
--- a/src/components/features/toc/SidebarTOC.astro
+++ b/src/components/features/toc/SidebarTOC.astro
@@ -137,6 +137,12 @@ const { class: className } = Astro.props;
 				top = (bottommost as HTMLElement).offsetTop - tocHeight * 0.8;
 			}
 
+			const maxTop = Math.max(0, scrollContainer.scrollHeight - tocHeight);
+			top = Math.max(0, Math.min(top, maxTop));
+
+			// 小于一个行高级别的位移不触发滚动，减少active更新时的抖动感
+			if (Math.abs((scrollContainer.scrollTop || 0) - top) < 24) return;
+
 			scrollContainer.scrollTo({ top, left: 0, behavior: "smooth" });
 		}, 100);
 

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -269,11 +269,11 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 					>
 						<div
 							id="toc-inner-wrapper"
-							class="fixed top-14 w-(--toc-width) max-h-[calc(100vh-10rem)] overflow-x-hidden overflow-y-auto"
+							class="fixed top-14 w-(--toc-width) h-[calc(100vh-6rem)] max-h-[calc(100vh-6rem)] overflow-x-hidden overflow-y-auto"
 						>
 							<div
 								id="toc-container"
-								class="w-full transition-swup-fade"
+								class="w-full h-full transition-swup-fade"
 							>
 								<SidebarTOC headings={headings} />
 							</div>

--- a/src/styles/banner.css
+++ b/src/styles/banner.css
@@ -40,7 +40,21 @@ body.no-banner-mode .absolute.w-full.z-30 {
 /* TOC 垂直对齐优化 */
 body.no-banner-mode #toc-inner-wrapper {
   top: 5.5rem !important;
+  height: calc(100vh - 8rem) !important;
   max-height: calc(100vh - 8rem) !important;
+}
+
+/* 低高度屏幕下给目录更多可用空间，避免滚动区域被过度压缩 */
+@media (max-height: 860px) {
+  #toc-inner-wrapper {
+    height: calc(100vh - 5.5rem) !important;
+    max-height: calc(100vh - 5.5rem) !important;
+  }
+
+  body.no-banner-mode #toc-inner-wrapper {
+    height: calc(100vh - 6.5rem) !important;
+    max-height: calc(100vh - 6.5rem) !important;
+  }
 }
 
 /* 全屏壁纸模式下的 TOC 毛玻璃背景 */


### PR DESCRIPTION
Summary
Improve sidebar TOC scroll boundary behavior in desktop sidebar mode, especially for low-height viewports.
Reduce tiny auto-follow scroll jitter during active heading updates.

Changes

Normalize TOC container height chain in [MainGridLayout.astro](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Add low-height viewport fallback in [banner.css](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Clamp target scrollTop and ignore tiny delta moves in [SidebarTOC.astro](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Validation
Long TOC can scroll from top to bottom
Banner and no-banner modes both behave correctly
Active heading auto-follow is smoother with less jitter
<img width="1874" height="956" alt="微信图片_20260411205448_2169_11" src="https://github.com/user-attachments/assets/ca828c04-9ac1-491b-918b-2ef4802faa19" />
<img width="1874" height="956" alt="Snipaste_2026-04-11_20-55-49" src="https://github.com/user-attachments/assets/54b7cc62-0431-4ddc-8756-1d7a3c01f00c" />
