### PR TITLE
fix(ShareCard): 修复海报生成器作者栏为空的问题

### DIFF
--- a/src/components/features/posts/ShareCard.astro
+++ b/src/components/features/posts/ShareCard.astro
@@ -28,6 +28,8 @@ const {
 	avatar,
 	class: className,
 } = Astro.props;
+
+const finalAuthor = author || profileConfig.name;
 ---
 
 <div
@@ -63,7 +65,7 @@ const {
 			<SharePoster
 				client:visible
 				{title}
-				{author}
+				author={finalAuthor}
 				description={description || ""}
 				{pubDate}
 				coverImage={coverImage ?? null}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

修复海报生成器作者栏为空的问题。

文章 schema 中 author 默认值为空字符串 `""`，导致 ShareCard 组件中的默认参数 `author = profileConfig.name` 不生效。添加了空字符串检查，确保使用配置文件中的作者名。


## How To Test

1. 创建一篇未设置作者的文章（frontmatter 中不写 author 字段）
2. 访问该文章页面
3. 点击底部"分享"按钮生成海报
4. 检查海报作者栏是否显示 `profileConfig.name`


## Screenshots (if applicable)

<img width="850" height="894" alt="poster-Simple-Guides-for-Mizuki" src="https://github.com/user-attachments/assets/af0611b6-baa0-4367-bae5-ee45bd562b93" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
