### PR TITLE
fix: 音樂播放器時間標籤改用自定義字體，提升主題字體設定一致性

### DIFF
--- a/src/components/widgets/music-sidebar/components/SidebarTrackInfo.svelte
+++ b/src/components/widgets/music-sidebar/components/SidebarTrackInfo.svelte
@@ -165,7 +165,7 @@
 		align-items: center;
 		gap: 0.2rem;
 		font-size: 10px;
-		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		font-family: inherit;
 		color: var(--content-meta);
 		white-space: nowrap;
 		flex-shrink: 0;


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->

Replaced `font-family: ui-monospace, SFMono-Regular, Menlo, monospace;` with `font-family: inherit;` in `src/components/widgets/music-sidebar/components/SidebarTrackInfo.svelte`

Before changing, when using the font that is not provided by the theme, and overwriting with custom fonts, the music player time label would not have the correct font loaded, and fallbacks to the one provided by the browser as default (monospace), which is ugly.

After replacing the whole string to `inherit` in font-family, the browser now respect to the custom fonts configured in settings, which would have a better visual experience in simple terms.

This change would also improve the consistency for font settings in the theme overall.

## How To Test

<!-- Please describe how you tested your changes. -->
Changed the settings and opened the music player, and the font-family was applied with no errors.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->

Before change: (with custom fonts)
<img width="631" height="359" alt="image" src="https://github.com/user-attachments/assets/80f66ddb-960b-4f98-a6e2-393baf329e8f" />


After change: (with custom fonts)
<img width="546" height="311" alt="image" src="https://github.com/user-attachments/assets/cf216a18-80ac-43df-8e7b-168e0956dc53" />


And here is the default one without custom fonts with this config applied.
<img width="578" height="345" alt="image" src="https://github.com/user-attachments/assets/16c4d29b-07dc-4c7b-847b-cab2d41b6013" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
