### PR TITLE
feat: 代碼塊改以 Expressive Code 字體設定為優先, 並改善對 Windows NT 系統 CJK 字體的支援

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -93,7 +93,7 @@ export default defineConfig({
 				borderColor: "none",
 				codeFontSize: "0.875rem",
 				codeFontFamily:
-					"'JetBrains Mono Variable', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+					"'JetBrains Mono Variable', SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', 'Microsoft JhengHei', '微軟正黑體', 'Microsoft YaHei', '微软雅黑', ui-monospace, monospace",
 				codeLineHeight: "1.5rem",
 				frames: {
 					editorBackground: "var(--codeblock-bg)",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -93,7 +93,7 @@ export default defineConfig({
 				borderColor: "none",
 				codeFontSize: "0.875rem",
 				codeFontFamily:
-					"'JetBrains Mono Variable', SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', 'Microsoft JhengHei', '微軟正黑體', 'Microsoft YaHei', '微软雅黑', ui-monospace, monospace",
+					"'JetBrains Mono Variable', SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', 'Microsoft JhengHei', '微軟正黑體', 'Microsoft YaHei', '微软雅黑', 'Noto Sans HK', 'Noto Sans TC', 'Noto Sans JP', 'Noto Sans SC', 'Noto Sans KR', ui-monospace, monospace",
 				codeLineHeight: "1.5rem",
 				frames: {
 					editorBackground: "var(--codeblock-bg)",

--- a/src/plugins/expressive-code/language-badge.ts
+++ b/src/plugins/expressive-code/language-badge.ts
@@ -26,7 +26,19 @@ export function pluginLanguageBadge() {
           top: 0.5rem;
           padding: 0.1rem 0.5rem;
           content: attr(data-language);
-          font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+          font-family: var(
+            --ec-codeFontFml,
+            "JetBrains Mono Variable",
+            "JetBrains Mono",
+            ui-monospace,
+            SFMono-Regular,
+            Menlo,
+            Monaco,
+            Consolas,
+            "Liberation Mono",
+            "Courier New",
+            monospace
+          );
           font-size: 0.75rem;
           font-weight: bold;
           text-transform: uppercase;

--- a/src/styles/encrypted-content.css
+++ b/src/styles/encrypted-content.css
@@ -39,13 +39,13 @@
   @apply px-4 py-2 text-xs font-medium;
   background: var(--primary);
   color: white;
-  font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--ec-codeFontFml, "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
 }
 
 /* pre元素样式 */
 #decrypted-content .frame pre {
   @apply p-4 overflow-x-auto m-0;
-  font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--ec-codeFontFml, "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
   font-size: 0.875rem;
   line-height: 1.5rem;
   background: var(--codeblock-bg);
@@ -67,7 +67,7 @@
 
 /* 代码元素样式 */
 #decrypted-content code {
-  font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--ec-codeFontFml, "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
 }
 
 /* 内联代码样式 - 与markdown.css保持一致 */
@@ -306,7 +306,7 @@
   top: 0.5rem;
   padding: 0.1rem 0.5rem;
   content: attr(data-language);
-  font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--ec-codeFontFml, "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
   font-size: 0.75rem;
   font-weight: bold;
   text-transform: uppercase;

--- a/src/styles/expressive-code.css
+++ b/src/styles/expressive-code.css
@@ -19,7 +19,7 @@
   }
 
   .title {
-    font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-family: var(--ec-codeFontFml, "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
   }
 
   /* 复制按钮样式 (Copy Button) */

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -39,7 +39,7 @@
   code {
     @apply bg-(--inline-code-bg) text-(--inline-code-color) px-1 py-0.5 rounded-md overflow-hidden;
 
-    font-family: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-family: var(--ec-codeFontFml, "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
 
     &:before,
     &:after {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->
Update all hardcoded `font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;` for code blocks to including `--ec-codeFontFml` variable.

This approach utilize our `codeFontFamily` configured in `astro.config.mjs`, while keeping the default fonts in case needs to fallback.

Also, `codeFontFamily` will now included all common cjk fonts in Windows, including:

- `Microsoft JhengHei`
- `微軟正黑體` 
- `Microsoft YaHei`
- `微软雅黑`
- `Noto Sans HK`
- `Noto Sans TC` 
- `Noto Sans JP`
- `Noto Sans SC`
- `Noto Sans KR`

This change will provide a comprehensive support for users who needs write CJK text in their code block as content.

## How To Test

<!-- Please describe how you tested your changes. -->
Check if the CJK text is not using monospace as font anymore.

Result shown that CJK text in codeblock now works with its `font-family`, while English kept intact (JetBrains font).

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
`codeFontFamily` can be adjusted accordingly as you see fit.

This change also help to reduce hardcoded values which now users can simpily change `codeFontFamily` in `astro.config.mjs` and everything will look good.