### PR TITLE
調整音樂播放器時間標籤的字體大小

### DIFF
--- a/src/components/widgets/music-sidebar/components/SidebarTrackInfo.svelte
+++ b/src/components/widgets/music-sidebar/components/SidebarTrackInfo.svelte
@@ -164,7 +164,7 @@
 		display: flex;
 		align-items: center;
 		gap: 0.2rem;
-		font-size: 10px;
+		font-size: 0.75rem;
 		font-family: inherit;
 		color: var(--content-meta);
 		white-space: nowrap;
@@ -242,7 +242,7 @@
 		}
 
 		.time-label {
-			font-size: 9px;
+			font-size: 0.625rem;
 		}
 
 		.volume-wrap {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
#434

## Changes

<!-- Please describe the changes you made in this pull request. -->
Adjust the `font-size` for music player time label, after the changes have done in #434.

This PR aims to create a similar effect on `font-size` before #434, while with custom-fonts preserved.

The new font size are now set to `0.75rem` for desktops and `0.625rem` for mobiles respectively.

### Reason
Since `monospace` font is not the primary choice anymore, and custom fonts are preferred, while those fonts are usually having a smaller `font-size` than the default `monospace`, keeping the `font-size` as `10px` for desktop and `9px` for mobile respectively would resulting a lower font display resolution in general.

In my experience, I did not notice anything on my 2K monitor at home, but I did noticed significant degradation in terms of font display quality when using computers in public libraries with monitor resolution set to `1920x1080`.

Also, when using mobile devices to surf the website, the text was almost unreadable unless you have good vision.

## How To Test

<!-- Please describe how you tested your changes. -->

1. Changing `font-size` for desktop side only.

2. Deploy and check if it's correctly applied.

3. Desktop side applied, changing `font-size` for mobile devices.

4. Deploy and check if all changes has been correctly applied.

5. Performed some tests on low-quality display monitor and mobile devices.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->

Here is a screenshot before the changes in #434
<img width="556" height="288" alt="image" src="https://github.com/user-attachments/assets/7ad4fab9-d80b-4d47-97fe-ef41040826c5" />

After the changes in #434
<img width="902" height="1496" alt="image" src="https://github.com/user-attachments/assets/d809fd4f-6d21-42da-94ab-c5b86876e2e9" />
<img width="567" height="309" alt="image" src="https://github.com/user-attachments/assets/2e9d94e3-70e3-4494-967e-6c2545b39bda" />

And this is how the theme would looks like after the PR
(The difference is minimal but would be noticed if you zoomed in a bit and have a closer look )
<img width="946" height="1510" alt="image" src="https://github.com/user-attachments/assets/5465fa3f-9edc-47cf-8696-eb745c536ae0" />
<img width="576" height="299" alt="image" src="https://github.com/user-attachments/assets/0d6fef3f-fc0e-4e4b-9909-b64da9123aa7" />



## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
