### PR TITLE
Update LICENSE file with its correct format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright [Matsuzaka Yuki]
+Copyright 2025 Matsuzaka Yuki
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please describe): Fixing the format for the Apache License file.

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

```

APPENDIX: How to apply the Apache License to your work.

      To apply the Apache License to your work, attach the following
      boilerplate notice, with the fields enclosed by brackets "[]"
      replaced with your own identifying information. (Don't include
      the brackets!)  The text should be enclosed in the appropriate
      comment syntax for the file format. We also recommend that a
      file or class name and description of purpose be included on the
      same "printed page" as the copyright notice for easier
      identification within third-party archives.
```

In Apache License 2.0, using square brackets inside both author name and year **are not practical** in general. Also, **year of publishment should be included** when applying the Apache License 2.0.

Since I have no detailed infomation about when the project actually starts, this change pre-assumed the year of publishment based on the git history, which is year 2025 in short.