### PR TITLE
fix: Missing 'twitter:image', with adding og:width and og:height to the HeadTags

### DIFF
--- a/src/layouts/partials/HeadTags.astro
+++ b/src/layouts/partials/HeadTags.astro
@@ -62,6 +62,8 @@ const favicons: Favicon[] =
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description || title} />
 {ogImageUrl && <meta property="og:image" content={ogImageUrl} />}
+{ogImageUrl && <meta property="og:image:width" content="1200" />}
+{ogImageUrl && <meta property="og:image:height" content="630" />}
 {
 	setOGTypeArticle ? (
 		<meta property="og:type" content="article" />
@@ -75,7 +77,7 @@ const favicons: Favicon[] =
 <meta property="twitter:url" content={Astro.url} />
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description || title} />
-
+{ogImageUrl && <meta name="twitter:image" content={ogImageUrl} />}
 <!-- Viewport and Generator -->
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->

Add `<meta name="twitter:image" content={ogImageUrl} />` to `HeadTags.astro` when `ogImageUrl` exists to fix Twitter (X) OG rendering issues.

This change also involves adding a fixed value of `og:width` and `og:height` (1200x630) to `HeadTags.astro` since facebook was complaining that which makes the OG cannot be rendered properly sometimes.

## How To Test

<!-- Please describe how you tested your changes. -->

1. Getting errors from facebook developers tools, as in the screenshots below.

2. Clear all caches after applying the fix.

3. The error mentioned above disappeared.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->

Before changing
<img width="1387" height="340" alt="image" src="https://github.com/user-attachments/assets/671706a5-02c8-4161-82df-49e98f4d0881" />

After the fix
<img width="1361" height="208" alt="image" src="https://github.com/user-attachments/assets/929ecb4c-1c2c-4e10-8afe-a215b0745eeb" />

The error `fb:app_id` missing could be ignored, as stated in https://stackoverflow.com/questions/35066102/facebook-debugger-why-complaining-about-app-id-missing.

## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->