### PR TITLE
feat(og): Support using post cover or banner for OG image accordingly if generateOgImages were disabled

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -29,9 +29,10 @@ interface Props {
 	lang?: string;
 	setOGTypeArticle?: boolean;
 	postSlug?: string;
+	coverImage?: string;
 }
 
-let { title, banner, description, lang, setOGTypeArticle, postSlug } =
+let { title, banner, description, lang, setOGTypeArticle, postSlug, coverImage } =
 	Astro.props;
 
 // apply a class to the body element to decide the height of the banner, only used for initial page load
@@ -100,7 +101,17 @@ if (title) {
 
 let ogImageUrl: string | undefined;
 if (siteConfig.generateOgImages && postSlug) {
-	ogImageUrl = new URL(`/og/${postSlug}.png`, Astro.site).toString();
+    ogImageUrl = new URL(`/og/${postSlug}.png`, Astro.site).toString();
+} else if (coverImage) {
+    // For post pages with cover images, use the resolved cover image
+    ogImageUrl = coverImage.startsWith('http')
+        ? coverImage
+        : new URL(coverImage, Astro.site).toString();
+} else if (banner) {
+    // For others, use the first banner as OG image
+    ogImageUrl = banner.startsWith('http')
+        ? banner
+        : new URL(banner, Astro.site).toString();
 }
 
 // const siteLang = siteConfig.lang.replace('_', '-')

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -32,6 +32,7 @@ interface Props {
 	setOGTypeArticle?: boolean;
 	postSlug?: string;
 	headings?: MarkdownHeading[];
+	coverImage?: string;
 }
 
 // 获取 banner 图片
@@ -44,6 +45,7 @@ const {
 	lang,
 	setOGTypeArticle,
 	postSlug,
+	coverImage,
 	headings = [],
 } = Astro.props;
 const hasBannerCredit = siteConfig.banner.credit.enable;
@@ -95,6 +97,7 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 	lang={lang}
 	setOGTypeArticle={setOGTypeArticle}
 	postSlug={postSlug}
+	coverImage={coverImage}
 >
 	<GridScripts
 		navbarTransparentMode={siteConfig.banner?.navbar?.transparentMode ||

--- a/src/layouts/partials/HeadTags.astro
+++ b/src/layouts/partials/HeadTags.astro
@@ -62,6 +62,8 @@ const favicons: Favicon[] =
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description || title} />
 {ogImageUrl && <meta property="og:image" content={ogImageUrl} />}
+{ogImageUrl && <meta property="og:image:width" content="1200" />}
+{ogImageUrl && <meta property="og:image:height" content="630" />}
 {
 	setOGTypeArticle ? (
 		<meta property="og:type" content="article" />
@@ -75,7 +77,7 @@ const favicons: Favicon[] =
 <meta property="twitter:url" content={Astro.url} />
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description || title} />
-
+{ogImageUrl && <meta name="twitter:image" content={ogImageUrl} />}
 <!-- Viewport and Generator -->
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -32,6 +32,8 @@ import Encryptor from "../../components/features/auth/Encryptor.astro";
 import { profileConfig, siteConfig } from "../../config";
 import { formatDateToYYYYMMDD } from "../../utils/date-utils";
 
+import { getImage } from "astro:assets";
+
 export async function getStaticPaths() {
 	const blogEntries = await getSortedPosts();
 
@@ -104,8 +106,10 @@ const relatedPosts = relatedPostsConfig.enable
 	? await getRelatedPosts(entry, relatedPostsConfig.maxCount)
 	: [];
 
-// Process cover image for SharePoster
+// Process cover image, for both OG and SharePoster
+let ogCoverUrl: string | undefined;
 let posterCoverUrl = entry.data.image;
+
 if (entry.data.image) {
 	const isLocal = !(
 		entry.data.image.startsWith("/") ||
@@ -125,8 +129,21 @@ if (entry.data.image) {
 		if (file) {
 			const img = await file();
 			posterCoverUrl = img.src;
+
+			// Resize for OG
+			const ogImage = await getImage({
+				src: img,
+				width: 1200,
+				format: "jpeg",
+				quality: 80,
+			});
+			ogCoverUrl = ogImage.src;
 		}
 	} else if (entry.data.image.startsWith("http")) {
+		// Retain the original URL for OG
+		ogCoverUrl = entry.data.image;
+
+		// Convert to base64 only for poster
 		try {
 			const response = await fetch(entry.data.image);
 			const arrayBuffer = await response.arrayBuffer();
@@ -137,6 +154,8 @@ if (entry.data.image) {
 		} catch {
 			posterCoverUrl = entry.data.image;
 		}
+	} else {
+		ogCoverUrl = entry.data.image;  // absolute path like "/images/foo.png"
 	}
 }
 
@@ -194,6 +213,7 @@ const jsonLd = {
 	setOGTypeArticle={true}
 	postSlug={entry.id}
 	headings={headings}
+	coverImage={ogCoverUrl}
 >
 	<script
 		is:inline


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->

Support using post cover for OG image, when `image` was specified inside the post frontmatter.

This new logic will be applied automatically for every single posts, if and only if `generateOgImages` were disabled in `config.ts`.

For non-post page (e.g. friends page / home page etc.) where no images specified, this PR fallbacks to secondary approach and uses the banner (typically the first desktop banner based on the original value of `banner`) for the OG image, regardless of the value `generateOgImages` it was set to.

### File changed

### `[...slug].astro`

The part which processing `posterCoverUrl` before are now being shared for processing `ogCoverUrl`. The difference between both variables are `ogCoverUrl` would be resized properly (with width 1200) in `jpeg` format. 

This would avoid if the source image files has a very large size which could potentially timeout or aborting the preview process. 

Also, `ogCoverUrl` will (keep) the source in raw `html` link instead of being converted to `base64` image if the source was `html`.

In addtion, `coverImage` will now also pass `ogCoverUrl` to `MainGridLayout.astro`.

Some comments were made for clarification, while the logic for `posterCoverUrl` is fully preserved.

### `MainGridLayout.astro`

Adding `coverImage` as one of the Props, its value will be passing into `Layout.astro`.

### `Layout.astro`

Passing `ogImageUrl` to the original unchanged `HeadTags.astro`, now with 3 possible cases

- If `generateOgImages = true` -> ```ogImageUrl = new URL(`/og/${postSlug}.png`, Astro.site).toString();```
- If `generateOgImages = false` and post has cover -> `ogImageUrl = new URL(coverImage, Astro.site).toString();`
- If post has no cover or non-post pages -> `ogImageUrl = new URL(banner, Astro.site).toString();`

### Reason of change
Before changing, when `generateOgImages` were disabled in settings, most of the post have no link preview displayed properly, only has the URL with title and desc in OG preview. The same issue applied for all other non-post pages.

This PR would resolve the issue in most cases, providing a better experience for end-users when sharing post through social media by URL.

## How To Test

<!-- Please describe how you tested your changes. -->
1. Enabled `generateOgImages` in `config.ts`, generated OG works for post, while other pages works with banner
2. Disabled `generateOgImages` in `config.ts`, find a post which has cover, cover works for post as OG image, while other pages works with banner
3. Disabled `generateOgImages` in `config.ts`, find a post which has no cover, all pages works with banner as OG image

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->

### This was the preview before the changes made, on Threads
<img width="668" height="274" alt="image" src="https://github.com/user-attachments/assets/d2a6d284-0542-4206-b3b4-e4a02f1afac4" />

### On Discord
<img width="485" height="192" alt="image" src="https://github.com/user-attachments/assets/866cfc9b-da19-4e6b-87aa-c779c308d8c7" />


### After change (home page, no cover)
<img width="751" height="616" alt="image" src="https://github.com/user-attachments/assets/0971bb5d-616e-4ec0-8dbc-d12adb93477a" />

### After change (a random post that has cover)
<img width="753" height="584" alt="image" src="https://github.com/user-attachments/assets/29d5d295-fc71-43ed-88e0-34397f2dfc8f" />

### After change (a random post that has no cover)
<img width="722" height="537" alt="image" src="https://github.com/user-attachments/assets/3b993759-42cb-4893-ae10-886c41889ac6" />


### After change (encrypted post, no cover)
<img width="722" height="535" alt="image" src="https://github.com/user-attachments/assets/4c2c3d5f-995e-4a3a-a8c2-b82dad5e5d40" />



## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

For the secondary approach, at least one banner is required in the `config.ts`, or this PR will not work as designed.
This would not causing additional errors in general, while the OG preview in social media would acting like before in this case.

Also, I am still a bit unsure that the behavior for encrypted post with cover applied. Either loading the banner or cover itself? I would follow up for that when available and once this PR was merged.