### PR TITLE
fix: hide encrypted post summaries

### DIFF
--- a/src/components/features/posts/PostCard.astro
+++ b/src/components/features/posts/PostCard.astro
@@ -1,4 +1,5 @@
 ---
+import { getPostHomeContent } from "@utils/post-card-content";
 import { render } from "astro:content";
 import { Icon } from "astro-icon/components";
 
@@ -22,6 +23,7 @@ const {
 	category,
 	image,
 	description,
+	hideHomeContent,
 	pinned,
 	encrypted,
 	password,
@@ -32,6 +34,10 @@ const hasCover = image !== undefined && image !== null && image !== "";
 const coverWidth = "28%";
 
 const { remarkPluginFrontmatter } = await render(entry);
+const homeContent = getPostHomeContent(
+	{ description, hideHomeContent, password },
+	remarkPluginFrontmatter.excerpt,
+);
 ---
 
 <div
@@ -106,7 +112,7 @@ const { remarkPluginFrontmatter } = await render(entry);
 				{ "line-clamp-2 md:line-clamp-1": !description },
 			]}
 		>
-			{description || remarkPluginFrontmatter.excerpt}
+			{homeContent}
 		</div>
 
 		<div class="flex flex-wrap gap-2 mt-2">

--- a/src/components/features/posts/PostListItem.astro
+++ b/src/components/features/posts/PostListItem.astro
@@ -3,6 +3,7 @@ import { Icon } from "astro-icon/components";
 
 import type { PostForList } from "@/utils/content-utils";
 import { formatDateToYYYYMMDD } from "@/utils/date-utils";
+import { getPostPublicDescription } from "@/utils/post-card-content";
 import { getPostUrlBySlug } from "@/utils/url-utils";
 
 interface Props {
@@ -24,7 +25,10 @@ const {
 const displayDate =
 	dateFormat === "iso"
 		? post.data.published.toISOString().substring(0, 10)
-		: post.data.description || formatDateToYYYYMMDD(post.data.published);
+		: getPostPublicDescription(
+				post.data,
+				formatDateToYYYYMMDD(post.data.published),
+			);
 ---
 
 <a

--- a/src/components/widgets/feed/FeedInfo.astro
+++ b/src/components/widgets/feed/FeedInfo.astro
@@ -4,6 +4,7 @@ import { i18n } from "@i18n/translation";
 import MainGridLayout from "@layouts/MainGridLayout.astro";
 import { getSortedPosts } from "@utils/content-utils";
 import { formatDateToYYYYMMDD } from "@utils/date-utils";
+import { getPostPublicDescription } from "@utils/post-card-content";
 import { Icon } from "astro-icon/components";
 
 interface Props {
@@ -13,6 +14,8 @@ interface Props {
 const { type } = Astro.props;
 const posts = (await getSortedPosts()).filter((post) => !post.data.encrypted);
 const recentPosts = posts.slice(0, 6);
+const getDescription = (post: (typeof recentPosts)[number]) =>
+	getPostPublicDescription(post.data);
 
 const feedUrl = type === "rss" ? "rss.xml" : "atom.xml";
 const prefix = type === "rss" ? "rss" : "atom";
@@ -103,9 +106,9 @@ const t = (key: string) => i18n(key as I18nKey);
 									{post.data.title}
 								</a>
 							</h3>
-							{post.data.description && (
+							{getDescription(post) && (
 								<p class="text-75 mb-3 line-clamp-2">
-									{post.data.description}
+									{getDescription(post)}
 								</p>
 							)}
 							<div class="flex items-center gap-4 text-sm text-60">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -26,6 +26,7 @@ const postsCollection = defineCollection({
 		encrypted: z.boolean().optional().default(false),
 		password: z.string().optional().default(""),
 		passwordHint: z.string().optional().default(""),
+		hideHomeContent: z.boolean().optional(),
 
 		/* Posts alias */
 		alias: z.string().optional(),

--- a/src/content/posts/encrypted-post.md
+++ b/src/content/posts/encrypted-post.md
@@ -6,6 +6,7 @@ encrypted: true
 pinned: true
 password: "123456"
 passwordHint: "123456"
+hideHomeContent: true
 alias: "encrypted-example"
 tags: ["Test", "Encryption"]
 category: "Technology"
@@ -48,6 +49,7 @@ draft: false
 | `encrypted`   | Whether this post is password protected.                                                                                                                                                                    |
 | `password`    | The password to unlock the encrypted post.                                                                                                                                                                  |
 | `passwordHint`| A hint to help users remember the password. Displayed below the password input.                                                                                                                             |
+| `hideHomeContent` | Whether to hide public post summaries, including the home page, meta tags, feed/API summaries, and share previews. Defaults to `true` when `password` is set.                                      |
 
 ## Where to Place the Post Files
 
@@ -112,6 +114,7 @@ published: 2024-01-15
 encrypted: true
 password: "my-secret-password"
 passwordHint: "Hint: The password is my dog's name"
+hideHomeContent: true
 ---
 ```
 
@@ -122,6 +125,7 @@ passwordHint: "Hint: The password is my dog's name"
 | `encrypted`    | Yes      | Set to `true` to enable password protection              |
 | `password`     | Yes      | The password to unlock the post                          |
 | `passwordHint` | No       | A hint displayed below the password input to help users |
+| `hideHomeContent` | No   | Hide public summaries as `该文章已加密`. Defaults to `true` when `password` is set. Set to `false` to show the normal summary. |
 
 ### How the Unlock Box Looks
 

--- a/src/pages/[...permalink].astro
+++ b/src/pages/[...permalink].astro
@@ -25,6 +25,7 @@ import {
 	hasCustomPermalink,
 	initPostIdMap,
 } from "@utils/permalink-utils";
+import { getPostPublicDescription } from "@utils/post-card-content";
 import { getFileDirFromPath } from "@utils/url-utils";
 import type { CollectionEntry } from "astro:content";
 import { render } from "astro:content";
@@ -82,6 +83,10 @@ const { remarkPluginFrontmatter } = await render(entry);
 // 处理加密逻辑
 let encryptedContent = "";
 const isEncrypted = entry.data.encrypted && entry.data.password;
+const publicDescription = getPostPublicDescription(
+	entry.data,
+	entry.data.title,
+);
 
 if (isEncrypted) {
 	const contentToEncrypt = "MIZUKI-VERIFY:" + entry.body;
@@ -95,7 +100,7 @@ const jsonLd = {
 	"@context": "https://schema.org",
 	"@type": "BlogPosting",
 	headline: entry.data.title,
-	description: entry.data.description || entry.data.title,
+	description: publicDescription,
 	keywords: entry.data.tags,
 	author: {
 		"@type": "Person",
@@ -112,7 +117,7 @@ const jsonLd = {
 <MainGridLayout
 	banner={entry.data.image}
 	title={entry.data.title}
-	description={entry.data.description}
+	description={publicDescription}
 	lang={entry.data.lang}
 	setOGTypeArticle={true}
 	postSlug={entry.id}

--- a/src/pages/api/allPostMeta.json.ts
+++ b/src/pages/api/allPostMeta.json.ts
@@ -1,4 +1,5 @@
 import { getSortedPosts } from "@/utils/content-utils";
+import { getPostPublicDescription } from "@/utils/post-card-content";
 
 export async function GET() {
 	const posts = await getSortedPosts();
@@ -7,7 +8,7 @@ export async function GET() {
 		.map((post) => ({
 			id: post.id,
 			title: post.data.title,
-			description: post.data.description,
+			description: getPostPublicDescription(post.data),
 			published: post.data.published.getTime(),
 			category: post.data.category || "",
 			password: !!post.data.password,

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -14,10 +14,15 @@ const showCategoryBar = siteConfig.postListLayout.categoryBar?.enable ?? false;
 
 // 1. 修复类型兼容性：将 category 的 null 转换为 undefined
 const posts = sortedPostsList.map((post) => ({
-	...post,
+	id: post.id,
+	url: post.url,
 	data: {
-		...post.data,
+		title: post.data.title,
+		tags: post.data.tags,
 		category: post.data.category === null ? undefined : post.data.category,
+		published: post.data.published,
+		alias: post.data.alias,
+		permalink: post.data.permalink,
 	},
 }));
 

--- a/src/pages/atom.xml.ts
+++ b/src/pages/atom.xml.ts
@@ -8,6 +8,7 @@ import sanitizeHtml from "sanitize-html";
 import { profileConfig, siteConfig } from "@/config";
 import { getSortedPosts } from "@/utils/content-utils";
 import { initPostIdMap } from "@/utils/permalink-utils";
+import { getPostPublicDescription } from "@/utils/post-card-content";
 import { getPostUrl } from "@/utils/url-utils";
 
 const markdownParser = new MarkdownIt();
@@ -134,7 +135,7 @@ export async function GET(context: APIContext) {
     <id>${postUrl}</id>
     <published>${post.data.published.toISOString()}</published>
     <updated>${post.data.updated?.toISOString() || post.data.published.toISOString()}</updated>
-    <summary>${post.data.description || ""}</summary>
+    <summary>${getPostPublicDescription(post.data)}</summary>
     <content type="html"><![CDATA[${content}]]></content>
     <author>
       <name>${profileConfig.name}</name>

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -6,6 +6,7 @@ import { getCollection } from "astro:content";
 import satori from "satori";
 import sharp from "sharp";
 
+import { getPostPublicDescription } from "@/utils/post-card-content";
 import { removeFileExtension } from "@/utils/url-utils";
 
 import { profileConfig, siteConfig } from "../../config";
@@ -136,7 +137,7 @@ export async function GET({
 		day: "numeric",
 	});
 
-	const description = post.data.description;
+	const description = getPostPublicDescription(post.data);
 
 	const template = {
 		type: "div",

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -16,7 +16,9 @@ import Markdown from "@components/misc/Markdown.astro";
 import MainGridLayout from "@layouts/MainGridLayout.astro";
 import { getRelatedPosts, getSortedPosts } from "@utils/content-utils";
 import { hasCustomPermalink, initPostIdMap } from "@utils/permalink-utils";
+import { getPostPublicDescription } from "@utils/post-card-content";
 import { getFileDirFromPath, removeFileExtension } from "@utils/url-utils";
+import { getImage } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
 import { render } from "astro:content";
 import {
@@ -31,8 +33,6 @@ import Image from "../../components/atoms/Image/Image.astro";
 import Encryptor from "../../components/features/auth/Encryptor.astro";
 import { profileConfig, siteConfig } from "../../config";
 import { formatDateToYYYYMMDD } from "../../utils/date-utils";
-
-import { getImage } from "astro:assets";
 
 export async function getStaticPaths() {
 	const blogEntries = await getSortedPosts();
@@ -185,12 +185,16 @@ if (profileConfig.avatar) {
 
 // 判断是否为加密文章
 const isEncrypted = !!(entry.data.encrypted && entry.data.password);
+const publicDescription = getPostPublicDescription(
+	entry.data,
+	entry.data.title,
+);
 
 const jsonLd = {
 	"@context": "https://schema.org",
 	"@type": "BlogPosting",
 	headline: entry.data.title,
-	description: entry.data.description || entry.data.title,
+	description: publicDescription,
 	keywords: entry.data.tags,
 	author: {
 		"@type": "Person",
@@ -208,7 +212,7 @@ const jsonLd = {
 <MainGridLayout
 	banner={entry.data.image}
 	title={entry.data.title}
-	description={entry.data.description}
+	description={publicDescription}
 	lang={entry.data.lang}
 	setOGTypeArticle={true}
 	postSlug={entry.id}
@@ -330,7 +334,7 @@ const jsonLd = {
 						class:list={[{ "encrypted-hidden": isEncrypted }]}
 						title={entry.data.title}
 						author={entry.data.author}
-						description={entry.data.description}
+						description={publicDescription}
 						pubDate={formatDateToYYYYMMDD(entry.data.published)}
 						coverImage={posterCoverUrl}
 						url={Astro.url.toString()}

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -10,6 +10,7 @@ import sanitizeHtml from "sanitize-html";
 import { siteConfig } from "@/config";
 import { getSortedPosts } from "@/utils/content-utils";
 import { initPostIdMap } from "@/utils/permalink-utils";
+import { getPostPublicDescription } from "@/utils/post-card-content";
 import { getPostUrl } from "@/utils/url-utils";
 
 const markdownParser = new MarkdownIt();
@@ -115,7 +116,7 @@ export async function GET(context: APIContext) {
 
 		feed.push({
 			title: post.data.title,
-			description: post.data.description,
+			description: getPostPublicDescription(post.data),
 			pubDate: post.data.published,
 			link: getPostUrl(post),
 			// sanitize the new html string with corrected image paths

--- a/src/utils/post-card-content.ts
+++ b/src/utils/post-card-content.ts
@@ -1,0 +1,35 @@
+export const ENCRYPTED_POST_HOME_CONTENT = "该文章已加密";
+
+export interface PostHomeContentData {
+	description?: string;
+	hideHomeContent?: boolean;
+	password?: string | null;
+}
+
+function hasPassword(password?: string | null): boolean {
+	return typeof password === "string" && password.length > 0;
+}
+
+export function shouldHidePostHomeContent(
+	data: PostHomeContentData,
+): boolean {
+	return data.hideHomeContent ?? hasPassword(data.password);
+}
+
+export function getPostHomeContent(
+	data: PostHomeContentData,
+	excerpt: string,
+): string {
+	return getPostPublicDescription(data, excerpt);
+}
+
+export function getPostPublicDescription(
+	data: PostHomeContentData,
+	fallback = "",
+): string {
+	if (shouldHidePostHomeContent(data)) {
+		return ENCRYPTED_POST_HOME_CONTENT;
+	}
+
+	return data.description || fallback;
+}

--- a/tests/post-card-content.test.ts
+++ b/tests/post-card-content.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+	ENCRYPTED_POST_HOME_CONTENT,
+	getPostHomeContent,
+	getPostPublicDescription,
+} from "../src/utils/post-card-content.ts";
+
+describe("getPostHomeContent", () => {
+	it("hides post content by default when a password is set", () => {
+		const content = getPostHomeContent(
+			{
+				description: "private summary",
+				password: "secret",
+			},
+			"private excerpt",
+		);
+
+		assert.equal(content, ENCRYPTED_POST_HOME_CONTENT);
+	});
+
+	it("shows content for password protected posts when hiding is disabled", () => {
+		const content = getPostHomeContent(
+			{
+				description: "public summary",
+				hideHomeContent: false,
+				password: "secret",
+			},
+			"public excerpt",
+		);
+
+		assert.equal(content, "public summary");
+	});
+
+	it("shows content by default when no password is set", () => {
+		const content = getPostHomeContent(
+			{
+				description: "",
+			},
+			"plain excerpt",
+		);
+
+		assert.equal(content, "plain excerpt");
+	});
+
+	it("hides content when hiding is explicitly enabled without a password", () => {
+		const content = getPostHomeContent(
+			{
+				description: "hidden summary",
+				hideHomeContent: true,
+			},
+			"hidden excerpt",
+		);
+
+		assert.equal(content, ENCRYPTED_POST_HOME_CONTENT);
+	});
+});
+
+describe("getPostPublicDescription", () => {
+	it("hides public descriptions by default when a password is set", () => {
+		const description = getPostPublicDescription(
+			{
+				description: "private summary",
+				password: "secret",
+			},
+			"fallback title",
+		);
+
+		assert.equal(description, ENCRYPTED_POST_HOME_CONTENT);
+	});
+
+	it("hides public descriptions when hiding is explicitly enabled", () => {
+		const description = getPostPublicDescription(
+			{
+				description: "hidden summary",
+				hideHomeContent: true,
+			},
+			"fallback title",
+		);
+
+		assert.equal(description, ENCRYPTED_POST_HOME_CONTENT);
+	});
+
+	it("keeps normal fallback behavior when hiding is disabled", () => {
+		const description = getPostPublicDescription(
+			{
+				description: "",
+				hideHomeContent: false,
+				password: "secret",
+			},
+			"fallback title",
+		);
+
+		assert.equal(description, "fallback title");
+	});
+});


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

N/A

## Changes

- Add `hideHomeContent` frontmatter support for encrypted posts.
- Default encrypted posts with a configured `password` to hide public summary content.
- Replace public summary output with `该文章已加密` across homepage cards, post lists, detail metadata, feeds, API metadata, OG images, and archive island props.
- Avoid passing raw post descriptions/password-related data into the archive Svelte island.
- Add regression tests for default and explicit `hideHomeContent` behavior.
- Update the encrypted post example with the new top-level config.

## How To Test

- `node --test --experimental-strip-types tests/post-card-content.test.ts`
- `pnpm check`
- `pnpm build`
- Ran targeted ESLint on changed files; it completed with only existing `console` warnings in feed/build scripts.
- Verified built output no longer contains the raw encrypted example summary text.

## Screenshots (if applicable)

N/A

## Additional Notes

The placeholder text is currently fixed as `该文章已加密`, matching the requested display text. A future follow-up can route it through the existing i18n system if maintainers want localized placeholder text.