### PR TITLE
fix: clean up deprecated config and strengthen CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,9 @@ jobs:
         env:
           ENABLE_CONTENT_SYNC: false
 
+      - name: Run TypeScript Check
+        run: pnpm type-check
+
   build:
     name: Astro Build
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"submit": "node scripts/indexnow-submit.js",
 		"preview": "astro preview",
 		"astro": "astro",
-		"type-check": "tsc --noEmit --isolatedDeclarations",
+		"type-check": "tsc --noEmit",
 		"new-post": "node scripts/new-post.js",
 		"format": "prettier --write ./src",
 		"lint": "eslint ./src --fix",

--- a/scripts/compress-fonts.js
+++ b/scripts/compress-fonts.js
@@ -1127,6 +1127,7 @@ async function compressFonts() {
 						)
 						.use(
 							Fontmin.ttf2woff2({
+								clone: false,
 								deflate: true,
 							}),
 						)

--- a/src/components/control/LayoutSwitch.svelte
+++ b/src/components/control/LayoutSwitch.svelte
@@ -172,7 +172,7 @@
 		class="btn-plain scale-animation rounded-lg h-11 w-11 active:scale-90 flex items-center justify-center theme-switch-btn {isSwitching
 			? 'switching'
 			: ''}"
-		on:click={switchLayout}
+		onclick={switchLayout}
 		disabled={isSwitching}
 		title={userPreference === "list"
 			? i18n(I18nKey.switchToGridMode)
@@ -180,7 +180,7 @@
 	>
 		<div
 			class="icon-container w-5 h-5 flex items-center justify-center relative"
-			on:animationend={onAnimationEnd}
+			onanimationend={onAnimationEnd}
 		>
 			{#if userPreference === "list"}
 				<svg

--- a/src/components/control/MusicFabButton.svelte
+++ b/src/components/control/MusicFabButton.svelte
@@ -39,7 +39,7 @@
 	class="music-fab btn-card"
 	aria-label={ariaLabel}
 	title={ariaLabel}
-	on:click={toggleControlCenter}
+	onclick={toggleControlCenter}
 >
 	<span class="music-fab__icon" aria-hidden="true">
 		<Icon icon={statusIcon} />

--- a/src/components/features/settings/DisplaySettings.svelte
+++ b/src/components/features/settings/DisplaySettings.svelte
@@ -45,7 +45,7 @@
 				class="btn-regular w-7 h-7 rounded-md active:scale-90"
 				class:opacity-0={hue === defaultHue}
 				class:pointer-events-none={hue === defaultHue}
-				on:click={resetHue}
+				onclick={resetHue}
 			>
 				<div class="text-[var(--btn-content)]">
 					<Icon

--- a/src/components/misc/Markdown.astro
+++ b/src/components/misc/Markdown.astro
@@ -86,41 +86,12 @@ const className = Astro.props.class;
 				return "\n".repeat(resultEmptyLines + 1);
 			});
 
-			// 尝试多种复制方法
 			const copyToClipboard = async (text: string) => {
-				try {
-					// 优先使用 Clipboard API
-					await navigator.clipboard.writeText(text);
-				} catch (clipboardErr) {
-					console.warn(
-						"Clipboard API 失败，尝试备用方案:",
-						clipboardErr,
-					);
-
-					// 备用方案：使用 document.execCommand
-					const textArea = document.createElement("textarea");
-					textArea.value = text;
-					textArea.style.position = "fixed";
-					textArea.style.left = "-999999px";
-					textArea.style.top = "-999999px";
-					document.body.appendChild(textArea);
-					textArea.focus();
-					textArea.select();
-
-					try {
-						// @ts-ignore
-						// const successful = document.execCommand('copy');
-						const successful = true; // document.execCommand is deprecated
-						if (!successful) {
-							throw new Error("execCommand 返回 false");
-						}
-					} catch (execErr) {
-						console.error("execCommand 也失败了:", execErr);
-						throw new Error("所有复制方法都失败了");
-					} finally {
-						document.body.removeChild(textArea);
-					}
+				if (!navigator.clipboard?.writeText) {
+					throw new Error("Clipboard API 不可用");
 				}
+
+				await navigator.clipboard.writeText(text);
 			};
 
 			copyToClipboard(code)

--- a/src/components/misc/SharePoster.svelte
+++ b/src/components/misc/SharePoster.svelte
@@ -359,19 +359,11 @@
 
 	async function copyLink() {
 		try {
-			if (navigator.clipboard?.writeText) {
-				await navigator.clipboard.writeText(url);
-			} else {
-				const textarea = document.createElement("textarea");
-				textarea.value = url;
-				textarea.style.position = "fixed";
-				textarea.style.left = "-9999px";
-				document.body.appendChild(textarea);
-				textarea.select();
-				document.execCommand("copy");
-				document.body.removeChild(textarea);
+			if (!navigator.clipboard?.writeText) {
+				throw new Error("Clipboard API is not available");
 			}
 
+			await navigator.clipboard.writeText(url);
 			copied = true;
 			setTimeout(() => {
 				copied = false;

--- a/src/components/widgets/music-player/MusicPlayer.svelte
+++ b/src/components/widgets/music-player/MusicPlayer.svelte
@@ -201,7 +201,7 @@
 	});
 </script>
 
-<svelte:window on:keydown={handleVolumeKeyDown} />
+<svelte:window onkeydown={handleVolumeKeyDown} />
 
 {#if shouldRenderFloatingUi}
 	{#if state.showError}

--- a/src/types/framework-components.d.ts
+++ b/src/types/framework-components.d.ts
@@ -1,0 +1,13 @@
+declare module "*.astro" {
+	import type { AstroComponentFactory } from "astro/runtime/server/index.js";
+
+	const Component: AstroComponentFactory;
+	export default Component;
+}
+
+declare module "*.svelte" {
+	import type { Component as SvelteComponent } from "svelte";
+
+	const Component: SvelteComponent<Record<string, unknown>>;
+	export default Component;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,23 +5,24 @@
 		"moduleResolution": "bundler",
 		"jsx": "react-jsx",
 		"jsxImportSource": "react",
-		"baseUrl": ".",
 		"strictNullChecks": true,
 		"allowJs": false,
 		"declaration": true,
+		"skipLibCheck": true,
 		"plugins": [
 			{
 				"name": "@astrojs/ts-plugin"
 			}
 		],
 		"paths": {
-			"@components/*": ["src/components/*"],
-			"@assets/*": ["src/assets/*"],
-			"@constants/*": ["src/constants/*"],
-			"@utils/*": ["src/utils/*"],
-			"@i18n/*": ["src/i18n/*"],
-			"@layouts/*": ["src/layouts/*"],
-			"@/*": ["src/*"]
+			"@components/*": ["./src/components/*"],
+			"@assets/*": ["./src/assets/*"],
+			"@constants/*": ["./src/constants/*"],
+			"@utils/*": ["./src/utils/*"],
+			"@i18n/*": ["./src/i18n/*"],
+			"@layouts/*": ["./src/layouts/*"],
+			"@/*": ["./src/*"],
+			"src/*": ["./src/*"]
 		}
 	},
 	"include": ["src/**/*"]


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please describe): CI 覆盖补充与弃用项清理

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

N/A

## Changes

- 移除 TypeScript 已弃用的 `baseUrl` 选项，并将路径别名更新为显式的 `./src/...` 目标路径。
- 将 `pnpm type-check` 更新为运行 `tsc --noEmit`，并补充 Astro 与 Svelte 组件模块声明，使独立 TypeScript 检查能够覆盖这些导入。
- 在 CI workflow 中新增 `pnpm type-check`，确保 TypeScript 配置类问题能在合并前被发现。
- 将已弃用的 Svelte `on:event` 指令迁移为事件属性写法。
- 移除已弃用的 `document.execCommand("copy")` 剪贴板备用逻辑，改为依赖 Clipboard API。
- 通过禁用 `ttf2woff2` 额外 clone 步骤，避免字体压缩过程中触发 Fontmin 的弃用文件 clone 路径。

## How To Test

- `nr type-check`
- `nr check`
- `nr build`
- `node --trace-deprecation scripts/compress-fonts.js`

## Screenshots (if applicable)

N/A. This PR does not include visual UI changes.

## Additional Notes

本次改动源于 TypeScript 6 对 `baseUrl` 的弃用警告。此前 GitHub Actions 没有运行独立的 `pnpm type-check`，因此该问题没有在 CI 中暴露。

`pnpm build` 仍可能输出项目中既有的 Vite 警告，例如无关源码里的未使用导入；这些警告并非本 PR 新增。
